### PR TITLE
This PR adds the ability to deploy from a git repo as capistrano used to offer

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,9 @@ Role Variables
   keep_releases: 10 # Releases to keep after a new deployment. See "Pruning old releases".
   custom_tasks_path: "./custom-tasks" # Path to find custom pre and post tasks for each deployment step.
   current_dir: "current" # Softlink name. You should rarely changed it.
+  git_repo: git@github.com:USERNAME/REPO.git # Location of the git repository
+  git_branch: master # Branch to use when deploying
+  deploy_via: "rsync" # Method used to deliver the code to the server. Options are copy, rsync or git
 ```
 
 Dependencies

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,3 +5,5 @@ version_dir: "releases"
 current_dir: "current"
 keep_releases: 0
 deploy_via: "rsync"
+git_repo: git@github.com:USERNAME/REPO.git
+git_branch: master

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,3 +7,4 @@ keep_releases: 0
 deploy_via: "rsync"
 git_repo: git@github.com:USERNAME/REPO.git
 git_branch: master
+custom_tasks_path: "custom-tasks"

--- a/tasks/update-code.yml
+++ b/tasks/update-code.yml
@@ -41,11 +41,7 @@
 - name: Deploy existing code to remote servers
   copy: src={{ deploy_from }} dest={{ release_path.stdout }}
   when: deploy_via == 'copy'
-
-- debug: var=git_repo
-- debug: var="{{ deploy_to }}/shared"
-- debug: var="{{ git_branch }}"
-
+  
 - name: Update remote repository
   git: repo={{ git_repo }} dest={{ deploy_to }}/shared version={{ git_branch }} accept_hostkey=true update=yes
   when: deploy_via == 'git'

--- a/tasks/update-code.yml
+++ b/tasks/update-code.yml
@@ -42,6 +42,16 @@
   copy: src={{ deploy_from }} dest={{ release_path.stdout }}
   when: deploy_via == 'copy'
 
+- name: Update remote repository
+  git: repo={{ git_repo }} dest={{ deploy_to }}/shared depth=1 version={{ git_branch }}
+  when: deploy_via == 'git'
+
+- name: Export a copy of the repo
+  command: git checkout-index -f -a --prefix="{{ release_path.stdout }}/"
+  args:
+    chdir: {{ deploy_to }}/shared
+  when: deploy_via == 'git'
+
 - name: Copy release version into REVISION file
   shell: echo {{ timestamp.stdout }} > {{ release_path.stdout }}/REVISION
 

--- a/tasks/update-code.yml
+++ b/tasks/update-code.yml
@@ -42,14 +42,18 @@
   copy: src={{ deploy_from }} dest={{ release_path.stdout }}
   when: deploy_via == 'copy'
 
+- debug: var=git_repo
+- debug: var="{{ deploy_to }}/shared"
+- debug: var="{{ git_branch }}"
+
 - name: Update remote repository
-  git: repo={{ git_repo }} dest={{ deploy_to }}/shared depth=1 version={{ git_branch }}
+  git: repo={{ git_repo }} dest={{ deploy_to }}/shared version={{ git_branch }} accept_hostkey=true update=yes
   when: deploy_via == 'git'
 
 - name: Export a copy of the repo
   command: git checkout-index -f -a --prefix="{{ release_path.stdout }}/"
   args:
-    chdir: {{ deploy_to }}/shared
+    chdir: "{{ deploy_to }}/shared"
   when: deploy_via == 'git'
 
 - name: Copy release version into REVISION file

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,2 +1,0 @@
----
-custom_tasks_path: "custom-tasks"


### PR DESCRIPTION
@carlosbuenosvinos I moved the variable ```custom_tasks_path``` from the ```vars``` folder to the ```defaults``` just because then the recipe is cleaner as the only way to override a var defined under ```vars``` folder is by defining it again when you specify the role like this:

```yaml
vars:
  custom_tasks_path: bar # This gets ignored

roles:
  - { role: foo, custom_tasks_path: bar } # This is the only way to override it
```

With this change now it can be defined as a regular variable on the ```vars``` section of the playbook. If you don't agree you can obviously put it back :smile: 