### PR TITLE
Use of synchronize module

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,3 +8,4 @@ deploy_via: "rsync"
 git_repo: git@github.com:USERNAME/REPO.git
 git_branch: master
 custom_tasks_path: "custom-tasks"
+rsync_extra_params: ""

--- a/tasks/update-code.yml
+++ b/tasks/update-code.yml
@@ -31,7 +31,7 @@
   when: deploy_via == 'rsync'
 
 - name: Rsync application files to remote shared copy (in rsync case)
-  local_action: command rsync -azx --delete {{ deploy_from }} {{ inventory_hostname }}:{{ shared_path.stdout }}
+  synchronize: src={{ deploy_from }} dest={{ shared_path.stdout }} recursive=yes delete=yes archive=yes compress=yes rsync_opts={{ rsync_extra_params }}
   when: deploy_via == 'rsync'
 
 - name: Deploy existing code to servers

--- a/tasks/update-code.yml
+++ b/tasks/update-code.yml
@@ -35,7 +35,7 @@
   when: deploy_via == 'rsync'
 
 - name: Deploy existing code to servers
-  command: cp -pr {{ shared_path.stdout }} {{ deploy.release_path.stdout }}
+  command: cp -pr {{ shared_path.stdout }} {{ release_path.stdout }}
   when: deploy_via == 'rsync'
 
 - name: Deploy existing code to remote servers


### PR DESCRIPTION
While using rsync through local_action it's perfectly fine, I have found issues using it for slightly more complex deploy setups. For example, when the remote user is not the same as the local user executing the deploy.

Using the **[synchronize](http://docs.ansible.com/synchronize_module.html)** ansible module (a wrapper around rsync) addresses this issue.

Hope you'll find it useful! :)