### PR TITLE
Fixes git task: removes unnecessary command and stores repo in repo dir

### DIFF
--- a/tasks/update-code/git.yml
+++ b/tasks/update-code/git.yml
@@ -1,11 +1,8 @@
 ---
 - name: ANSISTRANO | GIT | Update remote repository
-  git: repo={{ ansistrano_git_repo }} dest={{ ansistrano_deploy_to }}/shared version={{ ansistrano_git_branch }} accept_hostkey=true update=yes
+  git: repo={{ ansistrano_git_repo }} dest={{ ansistrano_deploy_to }}/repo version={{ ansistrano_git_branch }} accept_hostkey=true update=yes
 
 - name: ANSISTRANO | GIT | Export a copy of the repo
   command: git checkout-index -f -a --prefix="{{ ansistrano_release_path.stdout }}/"
   args:
-    chdir: "{{ ansistrano_deploy_to }}/shared"
-
-- name: ANSISTRANO | GIT | Deploy git stored code to servers
-  git: repo={{ ansistrano_deploy_from }} dest={{ ansistrano_release_path.stdout }} accept_hostkey=true
+    chdir: "{{ ansistrano_deploy_to }}/repo"


### PR DESCRIPTION
This is to fix deployments that rely on the git cloning/updating.

1. Removal of the command that's not needed (see #24 )

2. Store the cloned repo in the `repo` dir instead of `shared` that is usually used for other stuff. This follows the capistrano naming practices described here: http://capistranorb.com/documentation/getting-started/structure/