### PR TITLE
Allow to set the release version from var

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Role Variables
   ansistrano_rsync_extra_params: "" # Extra parameters to use when deploying with rsync 
   ansistrano_git_repo: git@github.com:USERNAME/REPO.git # Location of the git repository
   ansistrano_git_branch: master # Branch to use when deploying
-  
+
   # Hooks: custom tasks if you need them
   ansistrano_before_setup_tasks_file: "{{ playbook_dir }}/<your-deployment-config>/my-before-setup-tasks.yml"
   ansistrano_after_setup_tasks_file: "{{ playbook_dir }}/<your-deployment-config>/my-after-setup-tasks.yml"
@@ -147,6 +147,13 @@ If everything has been set up properly, this command will create the following a
 |   |-- 20100509145325
 |-- shared
 ```
+
+### Serial deployments
+
+To prevent different timestamps when deploying to several servers using the [`serial`](http://docs.ansible.com/playbooks_delegation.html#rolling-update-batch-size) option, you should set the `ansistrano_release_version` variable.
+
+```ansible-playbook -i hosts -e "ansistrano_release_version=`date -u +%Y%m%d%H%M%SZ`" deploy.yml```
+
 
 Rollbacking
 -----------
@@ -218,10 +225,11 @@ Variables in custom tasks
 
 When writing your custom tasks files you may need some variables that Ansistrano makes available to you:
 
-* ```{{ ansistrano_timestamp.stdout }}```: Timestamp for the current deployment
+* ```{{ ansistrano_timestamp.stdout }}```: Timestamp for the current deployment (in UTC timezone)
 * ```{{ ansistrano_release_path.stdout }}```: Path to current deployment release (probably the one you are going to use the most)
 * ```{{ ansistrano_releases_path.stdout }}```: Path to releases folder
 * ```{{ ansistrano_shared_path.stdout }}```: Path to shared folder (where common releases assets can be stored)  
+* ```{{ ansistrano_release_version }}```: Directory name for the current deployment (by default equals to `{{ ansistrano_timestamp.stdout }}`)
 
 Pruning old releases
 --------------------

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -4,7 +4,7 @@ galaxy_info:
   description: Ansible role to deploy scripting applications like PHP, Python, Ruby, etc. in a Capistrano style
   company: Ansistrano
   license: MIT
-  min_ansible_version: 1.6
+  min_ansible_version: 1.7
   platforms:
   - name: EL
     versions:

--- a/tasks/update-code.yml
+++ b/tasks/update-code.yml
@@ -1,11 +1,17 @@
 ---
 # Update code deployment step
 - name: ANSISTRANO | Get release timestamp
-  command: date +%Y%m%d%H%M%S
+  local_action: command date -u +%Y%m%d%H%M%SZ
+  run_once: true
   register: ansistrano_timestamp
+  sudo: no
+
+- name: ANSISTRANO | Set release version from timestamp
+  set_fact: ansistrano_release_version="{{ ansistrano_timestamp.stdout }}"
+  when: ansistrano_release_version is not defined
 
 - name: ANSISTRANO | Get release path
-  command: echo "{{ ansistrano_deploy_to }}/{{ ansistrano_version_dir }}/{{ ansistrano_timestamp.stdout }}"
+  command: echo "{{ ansistrano_deploy_to }}/{{ ansistrano_version_dir }}/{{ ansistrano_release_version }}"
   register: ansistrano_release_path
 
 - name: ANSISTRANO | Get releases path
@@ -25,7 +31,7 @@
   when: ansistrano_deploy_via == 'git'
 
 - name: ANSISTRANO | Copy release version into REVISION file
-  shell: echo {{ ansistrano_timestamp.stdout }} > {{ ansistrano_release_path.stdout }}/REVISION
+  shell: echo {{ ansistrano_release_version }} > {{ ansistrano_release_path.stdout }}/REVISION
 
 - name: ANSISTRANO | Touches up the release code
   file: path={{ ansistrano_release_path.stdout }} state=directory recurse=yes mode="g+w"


### PR DESCRIPTION
* The ansistrano_release_version can be set from a var to override the computed timestamp
* The timestamp is computed with UTC timezone
* `Z` letter is added as timestamp suffix to prevent TZ confusions when reading the timestamp

See #30 