### PR TITLE
[WIP] Github releases api auto metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,8 @@ Role Variables
   ansistrano_rsync_extra_params: "" # Extra parameters to use when deploying with rsync 
   ansistrano_git_repo: git@github.com:USERNAME/REPO.git # Location of the git repository
   ansistrano_git_branch: master # Branch to use when deploying
-  
+  ansistrano_release_version: 20150520063000Z # When set, overrides the timestamp computed at runtime
+
   # Hooks: custom tasks if you need them
   ansistrano_before_setup_tasks_file: "{{ playbook_dir }}/<your-deployment-config>/my-before-setup-tasks.yml"
   ansistrano_after_setup_tasks_file: "{{ playbook_dir }}/<your-deployment-config>/my-after-setup-tasks.yml"
@@ -147,6 +148,13 @@ If everything has been set up properly, this command will create the following a
 |   |-- 20100509145325
 |-- shared
 ```
+
+### Serial deployments
+
+To prevent different timestamps when deploying to several servers using the [`serial`](http://docs.ansible.com/playbooks_delegation.html#rolling-update-batch-size) option, you should set the `ansistrano_release_version` variable.
+
+```ansible-playbook -i hosts -e "ansistrano_release_version=`date -u +%Y%m%d%H%M%SZ`" deploy.yml```
+
 
 Rollbacking
 -----------
@@ -218,10 +226,11 @@ Variables in custom tasks
 
 When writing your custom tasks files you may need some variables that Ansistrano makes available to you:
 
-* ```{{ ansistrano_timestamp.stdout }}```: Timestamp for the current deployment
+* ```{{ ansistrano_timestamp.stdout }}```: Timestamp for the current deployment (in UTC timezone)
 * ```{{ ansistrano_release_path.stdout }}```: Path to current deployment release (probably the one you are going to use the most)
 * ```{{ ansistrano_releases_path.stdout }}```: Path to releases folder
 * ```{{ ansistrano_shared_path.stdout }}```: Path to shared folder (where common releases assets can be stored)  
+* ```{{ ansistrano_release_version }}```: Directory name for the current deployment (by default equals to `{{ ansistrano_timestamp.stdout }}`)
 
 Pruning old releases
 --------------------

--- a/README.md
+++ b/README.md
@@ -88,12 +88,17 @@ Role Variables
   ansistrano_current_dir: "current" # Softlink name. You should rarely changed it.
   ansistrano_shared_paths: [] # Shared paths to symlink to release dir
   ansistrano_keep_releases: 0 # Releases to keep after a new deployment. See "Pruning old releases".
-  ansistrano_deploy_via: "rsync" # Method used to deliver the code to the server. Options are copy, rsync or git
+  ansistrano_deploy_via: "rsync" # Method used to deliver the code to the server. Options are copy, rsync, git, http, tarball
   ansistrano_rsync_extra_params: "" # Extra parameters to use when deploying with rsync 
   ansistrano_git_repo: git@github.com:USERNAME/REPO.git # Location of the git repository
   ansistrano_git_branch: master # Branch to use when deploying
   ansistrano_release_version: 20150520063000Z # When set, overrides the timestamp computed at runtime
-
+  ansistrano_github_enabled: false # set to true to set release_version, git_branch, and deploy_from
+                                  # using the github releases api, using the latest release
+  ansistrano_github_token: token # Oauth token generated at https://github.com/settings/tokens
+  ansistrano_github_username: username #github username
+  ansistrano_github_repo: username #git repo name
+  
   # Hooks: custom tasks if you need them
   ansistrano_before_setup_tasks_file: "{{ playbook_dir }}/<your-deployment-config>/my-before-setup-tasks.yml"
   ansistrano_after_setup_tasks_file: "{{ playbook_dir }}/<your-deployment-config>/my-after-setup-tasks.yml"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -17,6 +17,12 @@ ansistrano_shared_paths: []
 # Number of releases to keep in your hosts, if 0, unlimited releases will be kept
 ansistrano_keep_releases: 0
 
+# Dynamic release info from the github api
+ansistrano_github_enabled: false
+ansistrano_github_token: "token"
+ansistrano_github_user: "user"
+ansistrano_github_repo: "repo"
+
 # Deployment strategies variables
 ansistrano_deploy_via: "rsync"
 
@@ -26,3 +32,6 @@ ansistrano_git_branch: master
 
 ## RSYNC push strategy
 ansistrano_rsync_extra_params: ""
+
+## HTTP pull strategy
+ansistrano_http_local_tmp: "/tmp"

--- a/example/my-app/hosts
+++ b/example/my-app/hosts
@@ -1,1 +1,1 @@
-my-server.com ansible_ssh_user=root
+localhost

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -4,7 +4,7 @@ galaxy_info:
   description: Ansible role to deploy scripting applications like PHP, Python, Ruby, etc. in a Capistrano style
   company: Ansistrano
   license: MIT
-  min_ansible_version: 1.6
+  min_ansible_version: 1.7
   platforms:
   - name: EL
     versions:

--- a/tasks/update-code.yml
+++ b/tasks/update-code.yml
@@ -9,6 +9,23 @@
   set_fact: ansistrato_release_version="{{ ansistrano_timestamp.stdout }}"
   when: ansistrano_release_version is not defined
 
+- name: ANSISTRANO | GITHUB | Latest release from api
+  local_action: uri url="https://api.github.com/repos/{{ ansistrano_github_user }}/{{ ansistrano_github_repo }}/releases/latest" HEADER_Authorization="token {{ ansistrano_github_token }}"
+  register: ansistrano_github_info
+  when: ansistrano_github_enabled
+
+- name: ANSISTRANO | GITHUB | Set version from github
+  set_fact: ansistrano_release_version="{{ ansistrano_github_info.json.tag_name }}"
+  when: ansistrano_github_enabled
+
+- name: ANSISTRANO | GITHUB | Set git branch version
+  set_fact: ansistrano_git_branch="{{ ansistrano_github_info.json.tag_name }}"
+  when: ansistrano_github_enabled
+
+- name: ANSISTRANO | GITHUB | Set deploy url
+  set_fact: ansistrano_deploy_from="{{ ansistrano_github_info.json.tarball_url|replace('://','://{{ ansistrano_github_user }}:{{ ansistrano_github_token }}@') }}"
+  when: ansistrano_github_enabled
+
 - name: ANSISTRANO | Get release path
   command: echo "{{ ansistrano_deploy_to }}/{{ ansistrano_version_dir }}/{{ ansistrano_release_version }}"
   register: ansistrano_release_path
@@ -28,6 +45,14 @@
 - name: ANSISTRANO | GIT | Deploy using Git strategy
   include: update-code/git.yml
   when: ansistrano_deploy_via == 'git'
+
+- name: ANSISTRANO | HTTP | Deploy using Http+Tarball strategy
+  include: update-code/http.yml
+  when: ansistrano_deploy_via == 'http'
+
+- name: ANSISTRANO | TARBALL | Deploy using Tarball strategy
+  include: update-code/tarball.yml
+  when: ansistrano_deploy_via == 'tarball'
 
 - name: ANSISTRANO | Copy release version into REVISION file
   shell: echo {{ ansistrano_release_version }} > {{ ansistrano_release_path.stdout }}/REVISION

--- a/tasks/update-code.yml
+++ b/tasks/update-code.yml
@@ -1,11 +1,16 @@
 ---
 # Update code deployment step
 - name: ANSISTRANO | Get release timestamp
-  command: date +%Y%m%d%H%M%S
+  local_action: command date -u +%Y%m%d%H%M%SZ
+  run_once: true
   register: ansistrano_timestamp
 
+- name: ANSISTRANO | Set release version from timestamp
+  set_fact: ansistrato_release_version="{{ ansistrano_timestamp.stdout }}"
+  when: ansistrano_release_version is not defined
+
 - name: ANSISTRANO | Get release path
-  command: echo "{{ ansistrano_deploy_to }}/{{ ansistrano_version_dir }}/{{ ansistrano_timestamp.stdout }}"
+  command: echo "{{ ansistrano_deploy_to }}/{{ ansistrano_version_dir }}/{{ ansistrano_release_version }}"
   register: ansistrano_release_path
 
 - name: ANSISTRANO | Get releases path
@@ -25,7 +30,7 @@
   when: ansistrano_deploy_via == 'git'
 
 - name: ANSISTRANO | Copy release version into REVISION file
-  shell: echo {{ ansistrano_timestamp.stdout }} > {{ ansistrano_release_path.stdout }}/REVISION
+  shell: echo {{ ansistrano_release_version }} > {{ ansistrano_release_path.stdout }}/REVISION
 
 - name: ANSISTRANO | Touches up the release code
   file: path={{ ansistrano_release_path.stdout }} state=directory recurse=yes mode="g+w"

--- a/tasks/update-code/http.yml
+++ b/tasks/update-code/http.yml
@@ -1,0 +1,13 @@
+---
+# http basic auth is unhappy with get_url, not sure why
+- name: ANSISTRANO | HTTP | Download tarball
+  command: "curl --location -s -o {{ ansistrano_http_local_tmp }}/ANSISTRANO-{{ ansistrano_github_repo }}.{{ ansistrano_release_version }}.tar.gz  {{ ansistrano_deploy_from }}"
+  args:
+    creates: "{{ ansistrano_http_local_tmp }}/ANSISTRANO-{{ ansistrano_github_repo }}.{{ ansistrano_release_version }}.tar.gz"
+  delegate_to: 127.0.0.1
+
+- name: ANSISTRANO | HTTP | set ansistrano_deploy_from to tarball
+  set_fact: ansistrano_deploy_from="{{ ansistrano_http_local_tmp }}/ANSISTRANO-{{ ansistrano_github_repo }}.{{ ansistrano_release_version }}.tar.gz"
+
+- name: ANSISTRANO | HTTP | Deploy using tarball
+  include: tarball.yml

--- a/tasks/update-code/tarball.yml
+++ b/tasks/update-code/tarball.yml
@@ -1,0 +1,6 @@
+---
+- name: ANSISTRANO | TARBALL | Create release dir
+  file: path={{ ansistrano_release_path.stdout }} state=directory
+
+- name: ANSISTRANO | TARBALL | Deploy existing tarball to remote servers
+  unarchive: src={{ ansistrano_deploy_from }} dest={{ ansistrano_release_path.stdout }}


### PR DESCRIPTION
This patch allows you to deploy using metadata from the github releases api.

I also added a tarball deployment strategy and a http strategy since deploying using github tarball urls is my preferred setup.

The http strategy needs some cleanup, so its not keeping old tarballs around forever.
I would also like to find a way to use get_url but i couldn't get it too work with github basic auth.

I'm using the github versions for the release versions so I pulled in the set release version from pull request as a dep.