### PR TITLE
Release metadata pulled from the github api

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,11 @@ Role Variables
   ansistrano_rsync_extra_params: "" # Extra parameters to use when deploying with rsync 
   ansistrano_git_repo: git@github.com:USERNAME/REPO.git # Location of the git repository
   ansistrano_git_branch: master # Branch to use when deploying
-  
+  ansistrano_metadata_source: none # Method used to pull dynamic release informaiton like git_branch Options are none, github
+  ansistrano_github_token: token # Oauth token generated at https://github.com/settings/tokens
+  ansistrano_github_username: username #github username
+  ansistrano_github_repo: username #git repo name
+
   # Hooks: custom tasks if you need them
   ansistrano_before_setup_tasks_file: "{{ playbook_dir }}/<your-deployment-config>/my-before-setup-tasks.yml"
   ansistrano_after_setup_tasks_file: "{{ playbook_dir }}/<your-deployment-config>/my-after-setup-tasks.yml"

--- a/README.md
+++ b/README.md
@@ -92,10 +92,9 @@ Role Variables
   ansistrano_rsync_extra_params: "" # Extra parameters to use when deploying with rsync 
   ansistrano_git_repo: git@github.com:USERNAME/REPO.git # Location of the git repository
   ansistrano_git_branch: master # Branch to use when deploying
-  ansistrano_metadata_source: none # Method used to pull dynamic release informaiton like git_branch Options are none, github
+  ansistrano_metadata_source: none # Method used to pull dynamic release information like git_branch Options are none, github
   ansistrano_github_token: token # Oauth token generated at https://github.com/settings/tokens
-  ansistrano_github_username: username #github username
-  ansistrano_github_repo: username #git repo name
+  ansistrano_github_repo: username/repo #git repo name
 
   # Hooks: custom tasks if you need them
   ansistrano_before_setup_tasks_file: "{{ playbook_dir }}/<your-deployment-config>/my-before-setup-tasks.yml"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -26,3 +26,6 @@ ansistrano_git_branch: master
 
 ## RSYNC push strategy
 ansistrano_rsync_extra_params: ""
+
+# Dynamic metadata
+ansistrano_metadata_source: "none"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,6 +3,10 @@
   fail: msg="ansistrano_custom_tasks_path is not used anymore. Please, check the documentation at https://github.com/ansistrano/deploy"
   when: ansistrano_custom_tasks_path is defined
 
+- name: ANSISTRANO | Load dynamic metadata
+  include: metadata/github.yml
+  when: ansistrano_metadata_source == "github"
+
 - name: ANSISTRANO | Execute "Before Setup" Tasks
   include: "{{ ansistrano_before_setup_tasks_file | default('empty.yml') }}"
 

--- a/tasks/metadata/github.yml
+++ b/tasks/metadata/github.yml
@@ -1,0 +1,13 @@
+- name: ANSISTRANO | GITHUB | Latest release from api
+  local_action: uri url="https://api.github.com/repos/{{ ansistrano_github_user }}/{{ ansistrano_github_repo }}/releases/latest" HEADER_Authorization="token {{ ansistrano_github_token }}"
+  register: ansistrano_github_info
+  run_once: true
+
+- name: ANSISTRANO | GITHUB | Set version from github
+  set_fact: ansistrano_release_version="{{ ansistrano_github_info.json.tag_name }}"
+
+- name: ANSISTRANO | GITHUB | Set git branch version
+  set_fact: ansistrano_git_branch="{{ ansistrano_github_info.json.tag_name }}"
+
+- name: ANSISTRANO | GITHUB | Set deploy url
+  set_fact: ansistrano_deploy_from="{{ ansistrano_github_info.json.tarball_url|replace('://','://{{ ansistrano_github_user }}:{{ ansistrano_github_token }}@') }}"

--- a/tasks/metadata/github.yml
+++ b/tasks/metadata/github.yml
@@ -1,7 +1,8 @@
 - name: ANSISTRANO | GITHUB | Latest release from api
-  local_action: uri url="https://api.github.com/repos/{{ ansistrano_github_user }}/{{ ansistrano_github_repo }}/releases/latest" HEADER_Authorization="token {{ ansistrano_github_token }}"
+  local_action: uri url="https://api.github.com/repos/{{ ansistrano_github_repo }}/releases/latest" HEADER_Authorization="token {{ ansistrano_github_token }}"
   register: ansistrano_github_info
   run_once: true
+  sudo: no
 
 - name: ANSISTRANO | GITHUB | Set version from github
   set_fact: ansistrano_release_version="{{ ansistrano_github_info.json.tag_name }}"
@@ -10,4 +11,4 @@
   set_fact: ansistrano_git_branch="{{ ansistrano_github_info.json.tag_name }}"
 
 - name: ANSISTRANO | GITHUB | Set deploy url
-  set_fact: ansistrano_deploy_from="{{ ansistrano_github_info.json.tarball_url|replace('://','://{{ ansistrano_github_user }}:{{ ansistrano_github_token }}@') }}"
+  set_fact: ansistrano_deploy_from="{{ ansistrano_github_info.json.tarball_url }}?access_token={{ ansistrano_github_token }}"


### PR DESCRIPTION
This hits the github api, to pull release metadata.  I've implemented it as its own step so the various hooks will have this data.

Its also setup so you could add other metadata sources.  You could do something similar with a raw git repo, grabbing the latest release tag, or with an http api that returned metadata as json.