### PR TITLE
Avoid unnecessary directory recursion

### DIFF
--- a/tasks/setup.yml
+++ b/tasks/setup.yml
@@ -1,10 +1,10 @@
 ---
 # Setup folders
 - name: ANSISTRANO | Ensure deployment base path exists
-  file: state=directory recurse=yes path={{ ansistrano_deploy_to }}
+  file: state=directory path={{ ansistrano_deploy_to }}
 
 - name: ANSISTRANO | Ensure releases folder exists
-  file: state=directory recurse=yes path={{ ansistrano_deploy_to }}/{{ ansistrano_version_dir }}
+  file: state=directory path={{ ansistrano_deploy_to }}/{{ ansistrano_version_dir }}
 
 - name: ANSISTRANO | Ensure shared elements folder exists
-  file: state=directory recurse=yes path={{ ansistrano_deploy_to }}/shared
+  file: state=directory path={{ ansistrano_deploy_to }}/shared


### PR DESCRIPTION
It seems as if the Ansible file module _always_ traverses all files and subdirectories even though it doesn't have any `perms=1234` reason to do so. 

I noticed this on a project when the "Ensure base path" steps were stalling for 20 seconds each.

Since we are not changing perms here, we don't need `recurse=true`.