### PR TITLE
Display placeholders to hint where hooks exist

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -27,3 +27,6 @@ ansistrano_git_identity_key_path: ""
 
 ## RSYNC push strategy
 ansistrano_rsync_extra_params: ""
+
+# Show verbose hints about hooks during execution
+ansistrano_display_default_hooks: false

--- a/tasks/empty-verbose.yml
+++ b/tasks/empty-verbose.yml
@@ -1,0 +1,7 @@
+# This file acts as an informative placeholder in those Capistrano flow steps where
+# you don't currently execute any custom tasks
+---
+- name: ANSISTRANO | DEFAULT_HOOKS | {{ansistrano_hook_name}}
+  local_action: command true
+  changed_when: false
+  when: false

--- a/tasks/empty.yml
+++ b/tasks/empty.yml
@@ -1,7 +1,2 @@
-# This file acts as an informative placeholder in those Capistrano flow steps where
-# you don't currently execute any custom tasks
----
-- name: ANSISTRANO | DEFAULT_HOOKS | {{ansistrano_hook_name}}
-  local_action: command true
-  changed_when: false
-  when: false
+# This file is an empty placeholder in those Capistrano flow steps where
+# you don't currently execute any custom tasks and verbose_default_hooks is false

--- a/tasks/empty.yml
+++ b/tasks/empty.yml
@@ -1,2 +1,7 @@
-# This file is intentionally left empty and it is used in those Capistrano flow steps
-# where you don't need to execute any custom tasks
+# This file acts as an informative placeholder in those Capistrano flow steps where
+# you don't currently execute any custom tasks
+---
+- name: ANSISTRANO | DEFAULT_HOOKS | {{ansistrano_hook_name}}
+  local_action: command true
+  changed_when: false
+  when: false

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,34 +3,58 @@
   fail: msg="ansistrano_custom_tasks_path is not used anymore. Please, check the documentation at https://github.com/ansistrano/deploy"
   when: ansistrano_custom_tasks_path is defined
 
-- include: "{{ ansistrano_before_setup_tasks_file | default('empty.yml') }}
-    ansistrano_hook_name='Before Setup'"
+- include: "{{
+    ansistrano_before_setup_tasks_file
+    | default(ansistrano_display_default_hooks is defined and ansistrano_display_default_hooks)
+    | ternary('empty-verbose.yml', 'empty.yml')
+  }} ansistrano_hook_name='Before Setup'"
 
 - include: setup.yml
 
-- include: "{{ ansistrano_after_setup_tasks_file | default('empty.yml') }}
-    ansistrano_hook_name='After Setup'"
+- include: "{{
+    ansistrano_after_setup_tasks_file
+    | default(ansistrano_display_default_hooks is defined and ansistrano_display_default_hooks)
+    | ternary('empty-verbose.yml', 'empty.yml')
+  }} ansistrano_hook_name='After Setup'"
 
-- include: "{{ ansistrano_before_update_code_tasks_file | default('empty.yml') }}
-    ansistrano_hook_name='Before Update Code'"
+- include: "{{
+    ansistrano_before_update_code_tasks_file
+    | default(ansistrano_display_default_hooks is defined and ansistrano_display_default_hooks)
+    | ternary('empty-verbose.yml', 'empty.yml')
+  }} ansistrano_hook_name='Before Update Code'"
 
 - include: update-code.yml
 
-- include: "{{ ansistrano_after_update_code_tasks_file | default('empty.yml') }}
-    ansistrano_hook_name='After Update Code'"
+- include: "{{
+    ansistrano_after_update_code_tasks_file
+    | default(ansistrano_display_default_hooks is defined and ansistrano_display_default_hooks)
+    | ternary('empty-verbose.yml', 'empty.yml')
+  }} ansistrano_hook_name='After Update Code'"
 
-- include: "{{ ansistrano_before_symlink_tasks_file | default('empty.yml') }}
-    ansistrano_hook_name='Before Symlink'"
+- include: "{{
+    ansistrano_before_symlink_tasks_file
+    | default(ansistrano_display_default_hooks is defined and ansistrano_display_default_hooks)
+    | ternary('empty-verbose.yml', 'empty.yml')
+  }} ansistrano_hook_name='Before Symlink'"
 
 - include: symlink.yml
 
-- include: "{{ ansistrano_after_symlink_tasks_file | default('empty.yml') }}
-    ansistrano_hook_name='After Symlink'"
+- include: "{{
+    ansistrano_after_symlink_tasks_file
+    | default(ansistrano_display_default_hooks is defined and ansistrano_display_default_hooks)
+    | ternary('empty-verbose.yml', 'empty.yml')
+  }} ansistrano_hook_name='After Symlink'"
 
-- include: "{{ ansistrano_before_cleanup_tasks_file | default('empty.yml') }}
-    ansistrano_hook_name='Before Cleanup'"
+- include: "{{
+    ansistrano_before_cleanup_tasks_file
+    | default(ansistrano_display_default_hooks is defined and ansistrano_display_default_hooks)
+    | ternary('empty-verbose.yml', 'empty.yml')
+  }} ansistrano_hook_name='Before Cleanup'"
 
 - include: cleanup.yml
 
-- include: "{{ ansistrano_after_cleanup_tasks_file | default('empty.yml') }}
-    ansistrano_hook_name='After Cleanup'"
+- include: "{{
+    ansistrano_after_cleanup_tasks_file
+    | default(ansistrano_display_default_hooks is defined and ansistrano_display_default_hooks)
+    | ternary('empty-verbose.yml', 'empty.yml')
+  }} ansistrano_hook_name='After Cleanup'"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,26 +3,34 @@
   fail: msg="ansistrano_custom_tasks_path is not used anymore. Please, check the documentation at https://github.com/ansistrano/deploy"
   when: ansistrano_custom_tasks_path is defined
 
-- include: "{{ ansistrano_before_setup_tasks_file | default('empty.yml') }}"
+- include: "{{ ansistrano_before_setup_tasks_file | default('empty.yml') }}
+    ansistrano_hook_name='Before Setup'"
 
 - include: setup.yml
 
-- include: "{{ ansistrano_after_setup_tasks_file | default('empty.yml') }}"
+- include: "{{ ansistrano_after_setup_tasks_file | default('empty.yml') }}
+    ansistrano_hook_name='After Setup'"
 
-- include: "{{ ansistrano_before_update_code_tasks_file | default('empty.yml') }}"
+- include: "{{ ansistrano_before_update_code_tasks_file | default('empty.yml') }}
+    ansistrano_hook_name='Before Update Code'"
 
 - include: update-code.yml
 
-- include: "{{ ansistrano_after_update_code_tasks_file | default('empty.yml') }}"
+- include: "{{ ansistrano_after_update_code_tasks_file | default('empty.yml') }}
+    ansistrano_hook_name='After Update Code'"
 
-- include: "{{ ansistrano_before_symlink_tasks_file | default('empty.yml') }}"
+- include: "{{ ansistrano_before_symlink_tasks_file | default('empty.yml') }}
+    ansistrano_hook_name='Before Symlink'"
 
 - include: symlink.yml
 
-- include: "{{ ansistrano_after_symlink_tasks_file | default('empty.yml') }}"
+- include: "{{ ansistrano_after_symlink_tasks_file | default('empty.yml') }}
+    ansistrano_hook_name='After Symlink'"
 
-- include: "{{ ansistrano_before_cleanup_tasks_file | default('empty.yml') }}"
+- include: "{{ ansistrano_before_cleanup_tasks_file | default('empty.yml') }}
+    ansistrano_hook_name='Before Cleanup'"
 
 - include: cleanup.yml
 
-- include: "{{ ansistrano_after_cleanup_tasks_file | default('empty.yml') }}"
+- include: "{{ ansistrano_after_cleanup_tasks_file | default('empty.yml') }}
+    ansistrano_hook_name='After Cleanup'"


### PR DESCRIPTION
This advertises the availability of the Capistrano flow hooks (or whatever they are referred to) in the standard output. 

I think it would be a timesaver, hopefully preventing you from having to peruse the source code and/or going back and forth to the docs while developing your deployment playbook.
