### PR TITLE
Create shared dir if it doesnt exist

### DIFF
--- a/tasks/symlink.yml
+++ b/tasks/symlink.yml
@@ -1,5 +1,11 @@
 ---
 # Symlinks shared paths
+- name: ANSISTRANO | Ensure shared paths directory exists
+  file:
+    state: directory
+    path: "{{ ansistrano_deploy_to }}/shared/{{ item }}"
+  with_items: ansistrano_shared_paths
+
 - name: ANSISTRANO | Create softlinks for shared paths
   file:
     state: link

--- a/tasks/symlink.yml
+++ b/tasks/symlink.yml
@@ -1,7 +1,10 @@
 ---
 # Symlinks shared paths
 - name: ANSISTRANO | Create softlinks for shared paths
-  file: state=link path={{ ansistrano_release_path.stdout }}/{{ item }} src={{ ansistrano_deploy_to }}/shared/{{ item }}
+  file:
+    state: link
+    path: "{{ ansistrano_release_path.stdout }}/{{ item }}"
+    src: "{{ ansistrano_deploy_to }}/shared/{{ item }}"
   with_items: ansistrano_shared_paths
 
 # Performs symlink exchange


### PR DESCRIPTION
This commit makes sure that the shared paths directory exists before trying to link it into each release. This solves an error when you use the shared directory for the first time.