### PR TITLE
Always reveal current release name during deploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,11 +227,10 @@ Variables in custom tasks
 
 When writing your custom tasks files you may need some variables that Ansistrano makes available to you:
 
-* ```{{ ansistrano_timestamp.stdout }}```: Timestamp for the current deployment (in UTC timezone)
 * ```{{ ansistrano_release_path.stdout }}```: Path to current deployment release (probably the one you are going to use the most)
 * ```{{ ansistrano_releases_path.stdout }}```: Path to releases folder
-* ```{{ ansistrano_shared_path.stdout }}```: Path to shared folder (where common releases assets can be stored)  
-* ```{{ ansistrano_release_version }}```: Directory name for the current deployment (by default equals to `{{ ansistrano_timestamp.stdout }}`)
+* ```{{ ansistrano_shared_path.stdout }}```: Path to shared folder (where common releases assets can be stored)
+* ```{{ ansistrano_release_version }}```: Relative directory name for the release (by default equals to the current timestamp in UTC timezone)
 
 Pruning old releases
 --------------------

--- a/tasks/update-code.yml
+++ b/tasks/update-code.yml
@@ -1,13 +1,8 @@
 ---
 # Update code deployment step
-- name: ANSISTRANO | Get release timestamp
-  local_action: command date -u +%Y%m%d%H%M%SZ
+- local_action:
+    set_fact ansistrano_release_version={{ lookup('pipe', 'date -u +%Y%m%d%H%M%SZ') }}
   run_once: true
-  register: ansistrano_timestamp
-  sudo: no
-
-- name: ANSISTRANO | Set release version from timestamp
-  set_fact: ansistrano_release_version="{{ ansistrano_timestamp.stdout }}"
   when: ansistrano_release_version is not defined
 
 - name: ANSISTRANO | Get release path


### PR DESCRIPTION
Unless overriden by `-e | --extra-vars=`, this generates the release in the same way as before but sets it as a fact once and only once directly, making `ansistrano_timestamp.stdout` redundant(1). The exact assigned value is also conveniently printed in place of the task name.

I believe it adds a certain degree of warming confidence to be able to see the generated ID of the current deploy. You also get a friendly reminder of the variable name, so once you get to the scale where you use `serial`, it will be a bit more clear whether or are successfully overriding it (set_fact becomes skipped).

---
1. Possible BC break: I don't know why this was documented in the README as "two essentially identical variables that you can use"; [when would you _ever_ need the .stdout version?](https://github.com/ansistrano/deploy/blob/master/README.md#variables-in-custom-tasks).