### PR TITLE
Fix ansistrano shared path

### DIFF
--- a/tasks/setup.yml
+++ b/tasks/setup.yml
@@ -3,8 +3,12 @@
 - name: ANSISTRANO | Ensure deployment base path exists
   file: state=directory path={{ ansistrano_deploy_to }}
 
+- name: ANSISTRANO | Set releases path
+  command: echo "{{ ansistrano_deploy_to }}/{{ ansistrano_version_dir }}"
+  register: ansistrano_releases_path
+
 - name: ANSISTRANO | Ensure releases folder exists
-  file: state=directory path={{ ansistrano_deploy_to }}/{{ ansistrano_version_dir }}
+  file: state=directory path={{ ansistrano_releases_path }}
 
 - name: ANSISTRANO | Set shared path
   command: echo "{{ ansistrano_deploy_to }}/shared"

--- a/tasks/setup.yml
+++ b/tasks/setup.yml
@@ -6,5 +6,9 @@
 - name: ANSISTRANO | Ensure releases folder exists
   file: state=directory path={{ ansistrano_deploy_to }}/{{ ansistrano_version_dir }}
 
+- name: ANSISTRANO | Set shared path
+  command: echo "{{ ansistrano_deploy_to }}/shared"
+  register: ansistrano_shared_path
+
 - name: ANSISTRANO | Ensure shared elements folder exists
-  file: state=directory path={{ ansistrano_deploy_to }}/shared
+  file: state=directory path={{ ansistrano_shared_path }}

--- a/tasks/update-code.yml
+++ b/tasks/update-code.yml
@@ -11,12 +11,8 @@
   when: ansistrano_release_version is not defined
 
 - name: ANSISTRANO | Get release path
-  command: echo "{{ ansistrano_deploy_to }}/{{ ansistrano_version_dir }}/{{ ansistrano_release_version }}"
+  command: echo "{{ ansistrano_releases_path }}/{{ ansistrano_release_version }}"
   register: ansistrano_release_path
-
-- name: ANSISTRANO | Get releases path
-  command: echo "{{ ansistrano_deploy_to }}/{{ ansistrano_version_dir }}"
-  register: ansistrano_releases_path
 
 - include: "update-code/{{ ansistrano_deploy_via | default('rsync') }}.yml"
 

--- a/tasks/update-code/rsync.yml
+++ b/tasks/update-code/rsync.yml
@@ -1,10 +1,10 @@
 ---
 - name: ANSISTRANO | RSYNC | Get shared path (in rsync case)
-  command: echo "{{ ansistrano_deploy_to }}/shared/.shared-copy"
-  register: ansistrano_shared_path
+  command: echo "{{ ansistrano_shared_path }}/.shared-copy"
+  register: ansistrano_shared_rsync_copy_path
 
 - name: ANSISTRANO | RSYNC | Rsync application files to remote shared copy
-  synchronize: src={{ ansistrano_deploy_from }} dest={{ ansistrano_shared_path.stdout }} recursive=yes delete=yes archive=yes compress=yes rsync_opts={{ ansistrano_rsync_extra_params }}
+  synchronize: src={{ ansistrano_deploy_from }} dest={{ ansistrano_shared_rsync_copy_path.stdout }} recursive=yes delete=yes archive=yes compress=yes rsync_opts={{ ansistrano_rsync_extra_params }}
 
 - name: ANSISTRANO | RSYNC | Deploy existing code to servers
-  command: cp -pr {{ ansistrano_shared_path.stdout }} {{ ansistrano_release_path.stdout }}
+  command: cp -pr {{ ansistrano_shared_rsync_copy_path.stdout }} {{ ansistrano_release_path.stdout }}


### PR DESCRIPTION
Fix for issue #42.
ansistrano_shared_path is only defined in rsync task and it is not the correct value. Now it is registered in setup phase.

Moreover, ansistrano_relases_path registration have been moved to setup phase. In this way is register in its first usage.