### PR TITLE
Allow ansistrano to work with .ssh config files

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ Role Variables
   ansistrano_keep_releases: 0 # Releases to keep after a new deployment. See "Pruning old releases".
   ansistrano_deploy_via: "rsync" # Method used to deliver the code to the server. Options are copy, rsync, git or s3
   ansistrano_rsync_extra_params: "" # Extra parameters to use when deploying with rsync 
+  ansistrano_rsync_set_remote_user: yes # See [ansible synchronize module](http://docs.ansible.com/ansible/synchronize_module.html). Options are yes, no.
   ansistrano_git_repo: git@github.com:USERNAME/REPO.git # Location of the git repository
   ansistrano_git_branch: master # Branch to use when deploying
   ansistrano_git_identity_key_path: "" # If specified this file is copied over and used as the identity key for the git commands, path is relative to the playbook in which it is used

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -31,6 +31,10 @@ ansistrano_git_identity_key_path: ""
 
 ## RSYNC push strategy
 ansistrano_rsync_extra_params: ""
+## put user@ for the remote paths. If you have a custom ssh config to define
+## the remote user for a host that does not match the inventory user,
+## you should set this parameter to "no".
+ansistrano_rsync_set_remote_user: yes
 
 ## S3 get strategy
 ansistrano_s3_bucket: s3bucket

--- a/tasks/update-code/rsync.yml
+++ b/tasks/update-code/rsync.yml
@@ -4,7 +4,7 @@
   register: ansistrano_shared_rsync_copy_path
 
 - name: ANSISTRANO | RSYNC | Rsync application files to remote shared copy
-  synchronize: src={{ ansistrano_deploy_from }} dest={{ ansistrano_shared_rsync_copy_path.stdout }} recursive=yes delete=yes archive=yes compress=yes rsync_opts={{ ansistrano_rsync_extra_params }}
+  synchronize: src={{ ansistrano_deploy_from }} dest={{ ansistrano_shared_rsync_copy_path.stdout }} set_remote_user={{ ansistrano_rsync_set_remote_user }} recursive=yes delete=yes archive=yes compress=yes rsync_opts={{ ansistrano_rsync_extra_params }}
 
 - name: ANSISTRANO | RSYNC | Deploy existing code to servers
   command: cp -pr {{ ansistrano_shared_rsync_copy_path.stdout }} {{ ansistrano_release_path.stdout }}


### PR DESCRIPTION
I have an ssh alias for one of our servers and ansistrano didn't play nicely with that because it always tried to add [myusername]@alias to the ssh rsync command.