### PR TITLE
Added unarchive and s3+unarchive functionality.

### DIFF
--- a/tasks/update-code/s3_unarchive.yml
+++ b/tasks/update-code/s3_unarchive.yml
@@ -1,0 +1,3 @@
+---
+- include: s3.yml
+- include: unarchive.yml

--- a/tasks/update-code/unarchive.yml
+++ b/tasks/update-code/unarchive.yml
@@ -1,0 +1,17 @@
+---
+- name: ANSISTRANO | Unarchive | Stat source archived file
+  stat: path={{ ansistrano_release_path.stdout }}
+  register: ansistrano_release_path_archived
+
+- name: ANSISTRANO | Unarchive | Rename source archived file
+  command: mv {{ ansistrano_release_path.stdout }} {{ ansistrano_release_path.stdout }}.archived
+  when: ansistrano_release_path_archived.stat.exists
+
+- name: ANSISTRANO | Unarchive | Create directory to unarchive source
+  file:  path={{ ansistrano_release_path.stdout }} state=directory
+
+- name: ANSISTRANO | Unarchive | Unarchive source
+  unarchive: copy=no src={{ ansistrano_release_path.stdout }}.archived dest={{ ansistrano_release_path.stdout }}
+
+- name: ANSISTRANO | Unarchive | Delete archived file
+  file: path={{ ansistrano_release_path.stdout }}.archived state=absent


### PR DESCRIPTION
When the code is in an archived file (in my case tgz) the current version downloads it using the version as a name. Right after the download it tries to create the file "REVISION" "inside" the new version that it is supposed to be a folder instead of a file.
With this PR now it is possible to download an "archived" source and unarchive it.
As it is separated we don't care where the archived file comes from.
As it is not specified any format it should work with any compressed/archived format ansible can work with although I only tested it with a tgz so far.