### PR TITLE
quotes variable ansistrano_rsync_extra_params

### DIFF
--- a/tasks/update-code/rsync.yml
+++ b/tasks/update-code/rsync.yml
@@ -4,7 +4,7 @@
   register: ansistrano_shared_rsync_copy_path
 
 - name: ANSISTRANO | RSYNC | Rsync application files to remote shared copy
-  synchronize: src={{ ansistrano_deploy_from }} dest={{ ansistrano_shared_rsync_copy_path.stdout }} set_remote_user={{ ansistrano_rsync_set_remote_user }} recursive=yes delete=yes archive=yes compress=yes rsync_opts={{ ansistrano_rsync_extra_params }}
+  synchronize: src={{ ansistrano_deploy_from }} dest={{ ansistrano_shared_rsync_copy_path.stdout }} set_remote_user={{ ansistrano_rsync_set_remote_user }} recursive=yes delete=yes archive=yes compress=yes rsync_opts="{{ ansistrano_rsync_extra_params }}"
 
 - name: ANSISTRANO | RSYNC | Deploy existing code to servers
   command: cp -pr {{ ansistrano_shared_rsync_copy_path.stdout }} {{ ansistrano_release_path.stdout }}


### PR DESCRIPTION
The extra rsync parameters shouldn't be checked by ansible. For example, it
wasn't possible to use multiple `--include` parameters (which is supported by
rsync), because ansible complained about double parameters.