### PR TITLE
use template module for deploy key

### DIFF
--- a/tasks/update-code/git.yml
+++ b/tasks/update-code/git.yml
@@ -1,6 +1,6 @@
 ---
 - name: ANSISTRANO | GIT | Ensure GIT deployment key is up to date
-  copy:
+  template:
     src: "{{ ansistrano_git_identity_key_path }}"
     dest: "{{ ansistrano_deploy_to }}/git_identity_key"
     mode: 0400


### PR DESCRIPTION
When the GitHub deploy key is stored as an encrypted Ansible Vault variable in playbooks it'd be useful to have the [copy key task](/ansistrano/deploy/blob/master/tasks/update-code/git.yml#L3) use the template module instead. In my experience the template module behaves as a superset of copy module so the change would be backwards compatible. 

Imagine playbooks/vars that look like this:

group_vars/all/vault:
```
vault_github_deploy_key: |
  -----BEGIN RSA PRIVATE KEY-----
  ...
  -----END RSA PRIVATE KEY-----
```


roles/deploy/templates/deploy_key.pem.j2:
```
{{ vault_github_deploy_key }}
```

and then the updated task in ansistrano:
```
- name: ANSISTRANO | GIT | Ensure GIT deployment key is up to date
  template:
    src: "{{ ansistrano_git_identity_key_path }}"
    dest: "{{ ansistrano_deploy_to }}/git_identity_key"
    mode: 0400
  when: ansistrano_git_identity_key_path|trim != ""
```
and `ansistrano_git_identity_key_path = "roles/deploy/templates/deploy_key.pem.j2"`

So what ends up happening is `{{ ansistrano_deploy_to }}/git_identity_key` becomes the value of the `vault_github_deploy_key` variable, which can be encrypted and stored in version control.
