### PR TITLE
Add relative softlinks option

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -11,6 +11,10 @@ ansistrano_version_dir: "releases"
 # Softlink name for the current release
 ansistrano_current_dir: "current"
 
+# Whether the softlink should be made absolute or relative to ansistrano_deploy_to.
+# Change to "yes" to use relative link.
+ansistrano_relative_softlinks: no
+
 # Shared paths to symlink to release dir
 ansistrano_shared_paths: []
 

--- a/tasks/symlink-shared.yml
+++ b/tasks/symlink-shared.yml
@@ -5,6 +5,12 @@
   with_items: ansistrano_shared_paths
 
 # Symlinks shared paths
-- name: ANSISTRANO | Create softlinks for shared paths
+- name: ANSISTRANO | Create absolute softlinks for shared paths
   file: state=link path={{ ansistrano_release_path.stdout }}/{{ item }} src={{ ansistrano_deploy_to }}/shared/{{ item }}
   with_items: ansistrano_shared_paths
+  when: not ansistrano_relative_softlinks
+  
+- name: ANSISTRANO | Create relative softlinks for shared paths
+  file: state=link path={{ ansistrano_release_path.stdout }}/{{ item }} src=../../shared/{{ item }}
+  with_items: ansistrano_shared_paths
+  when: ansistrano_relative_softlinks

--- a/tasks/symlink.yml
+++ b/tasks/symlink.yml
@@ -1,4 +1,9 @@
 ---
 # Performs symlink exchange
-- name: ANSISTRANO | Change softlink to new release
+- name: ANSISTRANO | Change absolute softlink to new release
   file: state=link path={{ ansistrano_deploy_to }}/{{ ansistrano_current_dir }} src={{ ansistrano_release_path.stdout }}
+  when: not ansistrano_relative_softlinks
+  
+- name: ANSISTRANO | Change relative softlink to new release
+  file: state=link path={{ ansistrano_deploy_to }}/{{ ansistrano_current_dir }} src=./releases/{{ ansistrano_release_version }}
+  when: ansistrano_relative_softlinks


### PR DESCRIPTION
This adds an option for the user to specify that he or she would like to use relative symbolic links for the "current" directory and the "shared" directory.

This is in reference to this issue I opened: #92 