### PR TITLE
Use the full variable syntax

### DIFF
--- a/tasks/symlink-shared.yml
+++ b/tasks/symlink-shared.yml
@@ -2,9 +2,9 @@
 # Ensure symlinks target paths is absent
 - name: ANSISTRANO | Ensure shared paths targets are absent
   file: state=absent path={{ ansistrano_release_path.stdout }}/{{ item }}
-  with_items: ansistrano_shared_paths
+  with_items: "{{ ansistrano_shared_paths }}"
 
 # Symlinks shared paths
 - name: ANSISTRANO | Create softlinks for shared paths
   file: state=link path={{ ansistrano_release_path.stdout }}/{{ item }} src="{{ item | regex_replace('[^\/]*', '..') }}/../shared/{{ item }}"
-  with_items: ansistrano_shared_paths
+  with_items: "{{ ansistrano_shared_paths }}"


### PR DESCRIPTION
To get rid of:
`[DEPRECATION WARNING]: Using bare variables is deprecated. Update your playbooks so that the environment value uses the 
full variable syntax ('{{ansistrano_shared_paths}}'). This feature will be removed in a future release. Deprecation 
warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.`