### PR TITLE
Allow more shared path customization

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,10 +103,11 @@ Role Variables
 - vars:
   ansistrano_deploy_from: "{{ playbook_dir }}" # Where my local project is (relative or absolute path)
   ansistrano_deploy_to: "/var/www/my-app" # Base path to deploy to.
+  ansistrano_shared_path: "{{ ansistrano_deploy_to }}/shared"
   ansistrano_version_dir: "releases" # Releases folder name
   ansistrano_current_dir: "current" # Softlink name. You should rarely changed it.
   ansistrano_current_via: "symlink" # Deployment strategy who code should be deployed to current path. Options are symlink or rsync
-  ansistrano_shared_paths: [] # Shared paths to symlink to release dir
+  ansistrano_shared_paths: [] # Shared paths to symlink to release dir, use hashes with keys "src" and "path", eg. { src: "static", path: "public/static" }
   ansistrano_keep_releases: 0 # Releases to keep after a new deployment. See "Pruning old releases".
   ansistrano_deploy_via: "rsync" # Method used to deliver the code to the server. Options are copy, rsync, git, s3 or download.
   ansistrano_allow_anonymous_stats: yes

--- a/tasks/setup.yml
+++ b/tasks/setup.yml
@@ -15,10 +15,10 @@
     path: "{{ ansistrano_releases_path.stdout }}"
 
 - name: ANSISTRANO | Set shared path
-  command: echo "{{ ansistrano_deploy_to }}/shared"
-  register: ansistrano_shared_path
+  set_fact: ansistrano_shared_path="{{ ansistrano_deploy_to }}/shared"
+  when: ansistrano_shared_path is undefined
 
 - name: ANSISTRANO | Ensure shared elements folder exists
   file:
     state: directory
-    path: "{{ ansistrano_shared_path.stdout }}"
+    path: "{{ ansistrano_shared_path }}"

--- a/tasks/symlink-shared.yml
+++ b/tasks/symlink-shared.yml
@@ -3,13 +3,13 @@
 - name: ANSISTRANO | Ensure shared paths targets are absent
   file:
     state: absent
-    path: "{{ ansistrano_release_path.stdout }}/{{ item }}"
+    path: "{{ ansistrano_release_path.stdout }}/{{ item.path }}"
   with_items: "{{ ansistrano_shared_paths }}"
 
 # Symlinks shared paths
 - name: ANSISTRANO | Create softlinks for shared paths
   file:
     state: link
-    path: "{{ ansistrano_release_path.stdout }}/{{ item }}"
-    src: "{{ item | regex_replace('[^\\/]*', '..') }}/../shared/{{ item }}"
+    path: "{{ ansistrano_release_path.stdout }}/{{ item.path }}"
+    src: "{{ ansistrano_shared_path }}/{{ item.src }}"
   with_items: "{{ ansistrano_shared_paths }}"


### PR DESCRIPTION
I use webfaction and they need a specific directory structure for webapps and static files. Everything is in a `~/webapps` directory:
- `~/webapps/preview` for the app code for a preview stage/instance
- `~/webapps/preview_static` for the static files for that app
- `~/webapps/preview_media` for the uploaded files etc for that app

The ansistrano shared files task has the `/shared` path hardcoded, which does not work in that case.

I made two changes to make this work for me...

I changed the `ansistrano_shared_paths` variable to work with hashes instead of a list. That way you can set a source and target for the symlink. For example, to link the `public/static` dir in my app code/current deploy dir to `~/webapps/preview_static` i use this config then:

```
    - ansistrano_shared_paths:
      - { src: "preview_static", path: "public/static" }
      - { src: "preview_media", path: "public/media" }
```

So the paths in the hash are `src` relative to `{{ ansistrano_shared_path }}` and the `path` relative to the current `{{ ansistrano_release_path.stdout }}`.

Then I changed how `ansistrano_shared_path` is determined. Previously it was just set at runtime, now it is only set if undefined. It still defaults to `{{ ansistrano_deploy_to }}/shared` for compatibility, but it can be changed in a play.

```
- name: ANSISTRANO | Set shared path
  set_fact: ansistrano_shared_path="{{ ansistrano_deploy_to }}/shared"
  when: ansistrano_shared_path is undefined
```

So now i can set `ansistrano_shared_path: "{{ ansistrano_deploy_to }}"` in the play to get rid of the `shared` subdirectory.
