### PR TITLE
Allow shared paths to have nested folders

### DIFF
--- a/tasks/symlink-shared.yml
+++ b/tasks/symlink-shared.yml
@@ -6,10 +6,19 @@
     path: "{{ ansistrano_release_path.stdout }}/{{ item }}"
   with_items: "{{ ansistrano_shared_paths }}"
 
+# Ensure symlink shared paths are existing
+- name: ANSISTRANO | Ensure shared paths directories are existing
+  file:
+    state: directory
+    src: "{{ ansistrano_shared_path.stdout }}/{{ item }}"
+    path: "{{ ansistrano_release_path.stdout }}/{{ item }}"
+  with_items: "{{ ansistrano_shared_paths }}"
+
 # Symlinks shared paths
 - name: ANSISTRANO | Create softlinks for shared paths
   file:
+    force: yes
     state: link
+    src: "{{ ansistrano_shared_path.stdout }}/{{ item }}"
     path: "{{ ansistrano_release_path.stdout }}/{{ item }}"
-    src: "{{ item | regex_replace('[^\\/]*', '..') }}/../shared/{{ item }}"
   with_items: "{{ ansistrano_shared_paths }}"


### PR DESCRIPTION
At my work we're pretty enthusiastic about replacing Capistrano with an Ansible-based solution and Ansistrano just fits our needs.

However we have shared paths such as `public/assets` (full path: `/home/deploy_user/deploy/app_name/shared/public/assets`).

Ansistrano won't try to create the needed structure (public folder) and it won't symlink nothing at all.