### PR TITLE
Allow shared directory to be a symlink

### DIFF
--- a/tasks/setup.yml
+++ b/tasks/setup.yml
@@ -22,3 +22,4 @@
   file:
     state: directory
     path: "{{ ansistrano_shared_path.stdout }}"
+    follow: True


### PR DESCRIPTION
Add follow=True to shared directory check to allow shared to be a symlink