### PR TITLE
Using "force" when updating repo

### DIFF
--- a/tasks/update-code/git.yml
+++ b/tasks/update-code/git.yml
@@ -23,6 +23,7 @@
     version: "{{ ansistrano_git_branch }}"
     accept_hostkey: true
     update: yes
+    force: yes
     key_file: "{{ ansistrano_deploy_to }}/git_identity_key"
   when: ansistrano_git_identity_key_path|trim != ""
 

--- a/tasks/update-code/git.yml
+++ b/tasks/update-code/git.yml
@@ -13,6 +13,7 @@
     version: "{{ ansistrano_git_branch }}"
     accept_hostkey: true
     update: yes
+    force: yes
   when: ansistrano_git_identity_key_path|trim == ''
 
 - name: ANSISTRANO | GIT | Update remote repository using SSH key


### PR DESCRIPTION
Prior to 1.9, the default was `yes` but now it is `no`.

This would avoid errors with succeeding deploys such as:

"Local modifications exist in repository (force=no)"