### PR TITLE
Register git commit sha

### DIFF
--- a/tasks/update-code/git.yml
+++ b/tasks/update-code/git.yml
@@ -14,6 +14,7 @@
     accept_hostkey: true
     update: yes
     force: yes
+  register: ansistrano_git_commit_sha
   when: ansistrano_git_identity_key_path|trim == ''
 
 - name: ANSISTRANO | GIT | Update remote repository using SSH key
@@ -25,6 +26,7 @@
     update: yes
     force: yes
     key_file: "{{ ansistrano_deploy_to }}/git_identity_key"
+  register: ansistrano_git_commit_sha
   when: ansistrano_git_identity_key_path|trim != ""
 
 - name: ANSISTRANO | GIT | Export a copy of the repo

--- a/tasks/update-code/git.yml
+++ b/tasks/update-code/git.yml
@@ -14,7 +14,7 @@
     accept_hostkey: true
     update: yes
     force: yes
-  register: ansistrano_git_commit_sha
+  register: ansistrano_git_result
   when: ansistrano_git_identity_key_path|trim == ''
 
 - name: ANSISTRANO | GIT | Update remote repository using SSH key
@@ -26,7 +26,7 @@
     update: yes
     force: yes
     key_file: "{{ ansistrano_deploy_to }}/git_identity_key"
-  register: ansistrano_git_commit_sha
+  register: ansistrano_git_result
   when: ansistrano_git_identity_key_path|trim != ""
 
 - name: ANSISTRANO | GIT | Export a copy of the repo


### PR DESCRIPTION
Register the git commit sha into a variable. Currently this variable is not used, but it could be considered to store it in the `REVISION` file or something similar.

Fixes #134 