### PR TITLE
Improve shared path creation in rsync-current mode

### DIFF
--- a/tasks/symlink-shared.yml
+++ b/tasks/symlink-shared.yml
@@ -1,17 +1,11 @@
 ---
-# Ensure symlinks target paths is absent
-- name: ANSISTRANO | Ensure shared paths targets are absent
-  file:
-    state: absent
-    path: "{{ ansistrano_release_path.stdout }}/{{ item }}"
-  with_items: "{{ ansistrano_shared_paths }}"
-
 # Symlinks shared paths
 - name: ANSISTRANO | Create softlinks for shared paths
   file:
     state: link
     path: "{{ ansistrano_release_path.stdout }}/{{ item }}"
     src: "{{ item | regex_replace('[^\\/]*', '..') }}/../shared/{{ item }}"
+    force: yes
   with_items: "{{ ansistrano_shared_paths }}"
 
 # Remove previous .rsync-filter file (rsync current deployment)


### PR DESCRIPTION
Reduces possible downtime to a minimum by enforcing symlink instead of manually remove it and set it afterwards

We're had some issues with missing shared paths because of the removal and delayed creation.