### PR TITLE
Allow shared files

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -17,6 +17,9 @@ ansistrano_current_via: "symlink"
 # Shared paths to symlink to release dir
 ansistrano_shared_paths: []
 
+# Shared files to symlink to release dir
+ansistrano_shared_files: []
+
 # Number of releases to keep in your hosts, if 0, unlimited releases will be kept
 ansistrano_keep_releases: 0
 

--- a/tasks/symlink-shared.yml
+++ b/tasks/symlink-shared.yml
@@ -13,8 +13,8 @@
     path: "{{ ansistrano_deploy_to }}/shared/{{ item | dirname }}"
   with_items: "{{ ansistrano_shared_files }}"
 
-# Symlinks shared paths
-- name: ANSISTRANO | Create softlinks for shared paths
+# Symlinks shared paths and files
+- name: ANSISTRANO | Create softlinks for shared paths and files
   file:
     state: link
     path: "{{ ansistrano_release_path.stdout }}/{{ item }}"

--- a/tasks/symlink-shared.yml
+++ b/tasks/symlink-shared.yml
@@ -1,4 +1,18 @@
 ---
+# Ensure shared path exists
+- name: ANSISTRANO | Ensure shared paths exists
+  file:
+    state: directory
+    path: "{{ ansistrano_deploy_to }}/shared/{{ item }}"
+  with_items: "{{ ansistrano_shared_paths }}"
+
+# Ensure basedir shared files exists
+- name: ANSISTRANO | Ensure basedir shared files exists
+  file:
+    state: directory
+    path: "{{ ansistrano_deploy_to }}/shared/{{ item | dirname }}"
+  with_items: "{{ ansistrano_shared_files }}"
+
 # Symlinks shared paths
 - name: ANSISTRANO | Create softlinks for shared paths
   file:
@@ -6,7 +20,9 @@
     path: "{{ ansistrano_release_path.stdout }}/{{ item }}"
     src: "{{ item | regex_replace('[^\\/]*', '..') }}/../shared/{{ item }}"
     force: yes
-  with_items: "{{ ansistrano_shared_paths }}"
+  with_flattened:
+    - "{{ ansistrano_shared_paths }}"
+    - "{{ ansistrano_shared_files }}"
 
 # Remove previous .rsync-filter file (rsync current deployment)
 - name: ANSISTRANO | Ensure .rsync-filter is absent

--- a/test/tasks/create-shared-paths.yml
+++ b/test/tasks/create-shared-paths.yml
@@ -13,3 +13,13 @@
   file:
     state: directory
     path: "{{ ansistrano_deploy_to }}/shared/xxx/yyy/zzz"
+
+- name: ANSISTRANO | Ensure shared file 1 exists
+  file:
+    state: touch
+    path: "{{ ansistrano_deploy_to }}/shared/test.txt"
+
+- name: ANSISTRANO | Ensure shared file 2 exists
+  file:
+    state: touch
+    path: "{{ ansistrano_deploy_to }}/shared/foo/test.txt"

--- a/test/test.yml
+++ b/test/test.yml
@@ -25,6 +25,7 @@
       - xxx/yyy/zzz
     ansistrano_shared_files:
       - test.txt
+      - foo/test.txt
   roles:
     - { role: local-ansistrano }
 

--- a/test/test.yml
+++ b/test/test.yml
@@ -23,6 +23,8 @@
       - blah
       - foo/bar
       - xxx/yyy/zzz
+    ansistrano_shared_files:
+      - test.txt
   roles:
     - { role: local-ansistrano }
 


### PR DESCRIPTION
Hi,

For my workflow, i need to shared both folder and files (symfony app), i show that ansistrano not purpose them, i modify symlink-shared.yml to support shared files.

So now i can set ansistrano_shared_files in the playbook.

```
    ansistrano_shared_paths:
     - path/of/shared/dir
    ansistrano_shared_files:
     - path/of/shared/file
```
