### PR TITLE
Support repo_tree for git update-code

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ Role Variables
   # Variables used in the Git deployment strategy
   ansistrano_git_repo: git@github.com:USERNAME/REPO.git # Location of the git repository
   ansistrano_git_branch: master # What version of the repository to check out. This can be the full 40-character SHA-1 hash, the literal string HEAD, a branch name, or a tag name
+  ansistrano_git_repo_tree: "" # If specified the subtree of the repository to deploy
   ansistrano_git_identity_key_path: "" # If specified this file is copied over and used as the identity key for the git commands, path is relative to the playbook in which it is used
 
   # Variables used in the download deployment strategy

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -33,6 +33,7 @@ ansistrano_keep_releases: 0
 ## GIT pull strategy
 ansistrano_git_repo: git@github.com:USERNAME/REPO.git
 ansistrano_git_branch: master
+ansistrano_git_repo_tree: ""
 ansistrano_git_identity_key_path: ""
 
 ## RSYNC push strategy

--- a/tasks/update-code/git.yml
+++ b/tasks/update-code/git.yml
@@ -43,13 +43,13 @@
     path: "{{ ansistrano_release_path.stdout }}"
 
 - name: ANSISTRANO | GIT | Archive and unarchive repo to release path
-  shell: git archive {{ ansistrano_git_branch }} | tar -x -f - -C "{{ ansistrano_release_path.stdout }}"
+  shell: git archive --format=tar {{ ansistrano_git_branch }} | tar -x -f - -C "{{ ansistrano_release_path.stdout }}"
   args:
     chdir: "{{ ansistrano_deploy_to }}/repo"
   when: ansistrano_git_real_repo_tree == ""
 
 - name: ANSISTRANO | GIT | Archive and unarchive subtree["{{ ansistrano_git_real_repo_tree }}"] of repo to release path
-  shell: git archive {{ ansistrano_git_branch }} "{{ ansistrano_git_real_repo_tree }}" | tar -x --strip-components "{{ ansistrano_git_real_repo_tree.split('/') | length }}" -f - -C "{{ ansistrano_release_path.stdout }}"
+  shell: git archive --format=tar {{ ansistrano_git_branch }} "{{ ansistrano_git_real_repo_tree }}" | tar -x --strip-components "{{ ansistrano_git_real_repo_tree.split('/') | length }}" -f - -C "{{ ansistrano_release_path.stdout }}"
   args:
     chdir: "{{ ansistrano_deploy_to }}/repo"
   when: ansistrano_git_real_repo_tree != ""

--- a/tasks/update-code/git.yml
+++ b/tasks/update-code/git.yml
@@ -33,7 +33,23 @@
   command: shred -f "{{ ansistrano_deploy_to }}/git_identity_key"
   when: ansistrano_git_identity_key_path|trim != ""
 
-- name: ANSISTRANO | GIT | Export a copy of the repo
-  command: git checkout-index -f -a --prefix="{{ ansistrano_release_path.stdout }}/"
+- name: ANSISTRANO | GIT | Set git_real_repo_tree
+  set_fact:
+    ansistrano_git_real_repo_tree: "{{ ansistrano_git_repo_tree | trim | regex_replace('^[/]*', '') | regex_replace('[/]*$', '') }}"
+
+- name: ANSISTRANO | GIT | Create release folder
+  file:
+    state: directory
+    path: "{{ ansistrano_release_path.stdout }}"
+
+- name: ANSISTRANO | GIT | Archive and unarchive repo to release path
+  shell: git archive {{ ansistrano_git_branch }} | tar -x -f - -C "{{ ansistrano_release_path.stdout }}"
   args:
     chdir: "{{ ansistrano_deploy_to }}/repo"
+  when: ansistrano_git_real_repo_tree == ""
+
+- name: ANSISTRANO | GIT | Archive and unarchive subtree["{{ ansistrano_git_real_repo_tree }}"] of repo to release path
+  shell: git archive {{ ansistrano_git_branch }} "{{ ansistrano_git_real_repo_tree }}" | tar -x --strip-components "{{ ansistrano_git_real_repo_tree.split('/') | length }}" -f - -C "{{ ansistrano_release_path.stdout }}"
+  args:
+    chdir: "{{ ansistrano_deploy_to }}/repo"
+  when: ansistrano_git_real_repo_tree != ""

--- a/test/test.yml
+++ b/test/test.yml
@@ -173,6 +173,54 @@
   roles:
     - { role: local-ansistrano }
 
+- name: When deploying using Git (repo_tree with Single-Layer folder)
+  hosts: all
+  vars:
+    ansistrano_deploy_via: "git"
+    ansistrano_git_repo: https://github.com/ansistrano/deploy.git
+    ansistrano_git_branch: master
+    ansistrano_git_repo_tree: test
+    ansistrano_deploy_to: "/tmp/git/my-app.com"
+  pre_tasks:
+    - name: Clear ansistrano_deploy_to
+      file:
+        path: "{{ ansistrano_deploy_to }}"
+        state: absent
+  roles:
+    - { role: local-ansistrano }
+  tasks:
+    - name: Assert ansistrano_deploy_to/current/test.yml file does exist
+      stat:
+        path: "{{ ansistrano_deploy_to }}/current/test.yml"
+      register: st
+    - fail:
+        msg: "File not exists"
+      when: st.stat.exists is not defined or st.stat.exists == False or st.stat.isdir == True
+
+- name: When deploying using Git (repo_tree with Multi-Layer folder)
+  hosts: all
+  vars:
+    ansistrano_deploy_via: "git"
+    ansistrano_git_repo: https://github.com/ansistrano/deploy.git
+    ansistrano_git_branch: master
+    ansistrano_git_repo_tree: test/roles/
+    ansistrano_deploy_to: "/tmp/git/my-app.com"
+  pre_tasks:
+    - name: Clear ansistrano_deploy_to
+      file:
+        path: "{{ ansistrano_deploy_to }}"
+        state: absent
+  roles:
+    - { role: local-ansistrano }
+  tasks:
+    - name: Assert ansistrano_deploy_to/current/local-ansistrano symbolic link does exist
+      stat:
+        path: "{{ ansistrano_deploy_to }}/current/local-ansistrano"
+      register: st
+    - fail:
+        msg: "Symbolic link not exists"
+      when: st.stat.exists is not defined or st.stat.exists == False or st.stat.islnk == False
+
 # Tests for download strategy
 - name: Given no previous deploy with download strategy
   hosts: all


### PR DESCRIPTION
Hi @ricardclau 

I added role variable `ansistrano_git_repo_tree` to support repo_tree for git update-code, same as [capistrano repo_path configuration](http://capistranorb.com/documentation/getting-started/configuration/).

Please review it.
Thanks.
