### PR TITLE
Add a flag to cleanup releases with sudo permissions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ Role Variables
   ansistrano_keep_releases: 0 # Releases to keep after a new deployment. See "Pruning old releases".
   ansistrano_deploy_via: "rsync" # Method used to deliver the code to the server. Options are copy, rsync, git, s3 or download.
   ansistrano_allow_anonymous_stats: yes
+  ansistrano_cleanup_become: no # Cleanup old releases with root privileges.
 
   # Variables used in the rsync deployment strategy
   ansistrano_rsync_extra_params: "" # Extra parameters to use when deploying with rsync in a single string. Although Ansible allows an array this can cause problems if we try to add multiple --include args as it was reported in https://github.com/ansistrano/deploy/commit/e98942dc969d4e620313f00f003a7ea2eab67e86

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -53,3 +53,7 @@ ansistrano_s3_region: eu-west-1
 ## Sends anonymous stats to the www.ansistrano.com servers
 ## You can disallow it by just setting this parameter to "no" in your playbook
 ansistrano_allow_anonymous_stats: yes
+
+
+# Cleanup old releases with root privileges
+ansistrano_cleanup_become: no

--- a/tasks/cleanup.yml
+++ b/tasks/cleanup.yml
@@ -1,5 +1,9 @@
 ---
 # Clean up releases
+
+- debug: var=ansistrano_cleanup_become
+
 - name: ANSISTRANO | Clean up releases
   shell: ls -1dt {{ ansistrano_releases_path.stdout }}/* | tail -n +{{ ansistrano_keep_releases | int + 1 }} | xargs rm -rf
   when: ansistrano_keep_releases > 0
+  sudo: "{{ ansistrano_cleanup_become | bool }}"


### PR DESCRIPTION
Sometime this is neccessary due to bad file permissions in a release folder (eg. user uploads or other tasks when it  was live). 

This change will fix a ugly workaround i had some times. The only way to do this now is to add a copy of the cleanup with the additional sudo keyword. With this change it is easy to enable sudo on cleanup.

Default is of, so nothing changes. I also use the deprecated sudo keyword for 1.8 compatibility.