### PR TITLE
ensure shared targets are absent is back

### DIFF
--- a/tasks/symlink-shared.yml
+++ b/tasks/symlink-shared.yml
@@ -1,4 +1,15 @@
 ---
+# Ensure symlinks target paths is absent
+# This was removed in 1.7.3 to improve speed but it introduced regressions in cases where 
+# there are .gitkeep files in such folders (common practice in some PHP frameworks)
+- name: ANSISTRANO | Ensure shared paths targets are absent
+  file:
+    state: absent
+    path: "{{ ansistrano_release_path.stdout }}/{{ item }}"
+  with_flattened:
+    - "{{ ansistrano_shared_paths }}"
+    - "{{ ansistrano_shared_files }}"
+
 # Ensure shared path exists
 - name: ANSISTRANO | Ensure shared paths exists
   file:
@@ -19,7 +30,6 @@
     state: link
     path: "{{ ansistrano_release_path.stdout }}/{{ item }}"
     src: "{{ item | regex_replace('[^\\/]*', '..') }}/../shared/{{ item }}"
-    force: yes
   with_flattened:
     - "{{ ansistrano_shared_paths }}"
     - "{{ ansistrano_shared_files }}"

--- a/test/tasks/after-symlink.yml
+++ b/test/tasks/after-symlink.yml
@@ -1,1 +1,0 @@
-- service: name=httpd state=reloaded


### PR DESCRIPTION
Sorting out regression at #145 

Sorry @mblaschke but even if I hate compromising speed, at the moment maximum compatibility and not introducing regressions is more important to us than gaining some seconds (which in fact is a problem in Ansible) :(

Also, removing force: yes to ensure the symlinks are actually pointing somewhere