### PR TITLE
Fix "failed to checksum remote file. Checksum error code: 2" error.

### DIFF
--- a/tasks/update-code/git.yml
+++ b/tasks/update-code/git.yml
@@ -3,7 +3,7 @@
   template:
     src: "{{ ansistrano_git_identity_key_path }}"
     dest: "{{ ansistrano_deploy_to }}/git_identity_key"
-    mode: 0400
+    mode: 0600
   when: ansistrano_git_identity_key_path|trim != ""
 
 - name: ANSISTRANO | GIT | Update remote repository


### PR DESCRIPTION
The error is shown after the file is created for the first time.