### PR TITLE
Fix ansistrano_git_result register

### DIFF
--- a/tasks/update-code/git.yml
+++ b/tasks/update-code/git.yml
@@ -30,7 +30,7 @@
   when: ansistrano_git_identity_key_path|trim != ""
 
 - name: ANSISTRANO | GIT | Register ansistrano_git_result variable
-  set_fact: ansistrano_git_result={{ ansistrano_git_result_update_ssh if ansistrano_git_result_update.skipped else ansistrano_git_result_update }}
+  set_fact: ansistrano_git_result={{ ansistrano_git_result_update_ssh if ansistrano_git_result_update|skipped else ansistrano_git_result_update }}
 
 - name: ANSISTRANO | GIT | Shred GIT deployment key
   command: shred -f "{{ ansistrano_deploy_to }}/git_identity_key"

--- a/tasks/update-code/git.yml
+++ b/tasks/update-code/git.yml
@@ -14,7 +14,7 @@
     accept_hostkey: true
     update: yes
     force: yes
-  register: ansistrano_git_result
+  register: ansistrano_git_result_update
   when: ansistrano_git_identity_key_path|trim == ''
 
 - name: ANSISTRANO | GIT | Update remote repository using SSH key
@@ -26,8 +26,11 @@
     update: yes
     force: yes
     key_file: "{{ ansistrano_deploy_to }}/git_identity_key"
-  register: ansistrano_git_result
+  register: ansistrano_git_result_update_ssh
   when: ansistrano_git_identity_key_path|trim != ""
+
+- name: ANSISTRANO | GIT | Register ansistrano_git_result variable
+  set_fact: ansistrano_git_result={{ ansistrano_git_result_update_ssh if ansistrano_git_result_update.skipped else ansistrano_git_result_update }}
 
 - name: ANSISTRANO | GIT | Shred GIT deployment key
   command: shred -f "{{ ansistrano_deploy_to }}/git_identity_key"


### PR DESCRIPTION
Fixes erratic behaviour of #135. Ansible always registers the variables, even if tasks are skipped. This PR defines two variables, and then defines a third variable, with the previous name, with the value of whichever of the two wasn't skipped.