### PR TITLE
Support s3 rgw option

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,8 @@ Role Variables
   ansistrano_s3_bucket: s3bucket
   ansistrano_s3_object: s3object.tgz # Add the _unarchive suffix to the ansistrano_deploy_via if your object is a package (ie: s3_unarchive)
   ansistrano_s3_region: eu-west-1
+  ansistrano_s3_rgw: false # use Ceph RGW (when set true, ignore ansistrano_s3_region)
+  ansistrano_s3_url: http://rgw.example.com # when use Ceph RGW, set url
   # Optional variables, omitted by default
   ansistrano_s3_aws_access_key: YOUR_AWS_ACCESS_KEY
   ansistrano_s3_aws_secret_key: YOUR_AWS_SECRET_KEY

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ Role Variables
   ansistrano_s3_bucket: s3bucket
   ansistrano_s3_object: s3object.tgz # Add the _unarchive suffix to the ansistrano_deploy_via if your object is a package (ie: s3_unarchive)
   ansistrano_s3_region: eu-west-1
-  ansistrano_s3_rgw: false # use Ceph RGW (when set true, ignore ansistrano_s3_region)
+  ansistrano_s3_rgw: false # must be Ansible >= 2.2. use Ceph RGW (when set true, ignore ansistrano_s3_region)
   ansistrano_s3_url: http://rgw.example.com # when use Ceph RGW, set url
   # Optional variables, omitted by default
   ansistrano_s3_aws_access_key: YOUR_AWS_ACCESS_KEY

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -57,6 +57,7 @@ ansistrano_get_url: https://github.com/someproject/somearchive.tar.gz
 ansistrano_s3_bucket: s3bucket
 ansistrano_s3_object: s3object.tgz
 ansistrano_s3_region: eu-west-1
+ansistrano_s3_rgw: false
 
 ## Sends anonymous stats to the www.ansistrano.com servers
 ## You can disallow it by just setting this parameter to "no" in your playbook

--- a/tasks/update-code/s3.yml
+++ b/tasks/update-code/s3.yml
@@ -13,3 +13,17 @@
     region: "{{ ansistrano_s3_region }}"
     aws_access_key: "{{ ansistrano_s3_aws_access_key | default(omit) }}"
     aws_secret_key: "{{ ansistrano_s3_aws_secret_key | default(omit) }}"
+  when: not ansistrano_s3_rgw
+
+- name: ANSISTRANO | S3 | Get object from Ceph RGW
+  s3:
+    rgw: true
+    s3_url: "{{ ansistrano_s3_url }}"
+    encrypt: "{{ ansistrano_s3_encrypt | default(false) }}"
+    bucket: "{{ ansistrano_s3_bucket }}"
+    object: "{{ ansistrano_s3_object }}"
+    dest: "{{ ansistrano_release_path.stdout }}/{{ ansistrano_s3_object | basename }}"
+    mode: get
+    aws_access_key: "{{ ansistrano_s3_aws_access_key | default(omit) }}"
+    aws_secret_key: "{{ ansistrano_s3_aws_secret_key | default(omit) }}"
+  when: ansistrano_s3_rgw


### PR DESCRIPTION
I use s3-compatible object storage (Ceph RGW) for storing artifacts.
From ansible v2.2, ansible s3 module supports Ceph RGW.

Now, ansistrano support s3, so I just add an option for supporting Ceph RGW.
* even if use rgw, `ansistrano_deploy_via` is `s3` or `s3_unarchive`
* switch s3 or rgw by `ansistrano_s3_rgw` bool parameter
* when rgw is true, use `ansistrano_s3_url` as an s3 endpoint

# Reference 
* [ansible s3 module](http://docs.ansible.com/ansible/s3_module.html)
* [Ceph RGW](http://docs.ceph.com/docs/jewel/radosgw/)