### PR TITLE
add ability to put symlinks into shared folder

### DIFF
--- a/tasks/symlink-shared.yml
+++ b/tasks/symlink-shared.yml
@@ -14,6 +14,7 @@
 - name: ANSISTRANO | Ensure shared paths exists
   file:
     state: directory
+    follow: yes
     path: "{{ ansistrano_deploy_to }}/shared/{{ item }}"
   with_items: "{{ ansistrano_shared_paths }}"
 
@@ -21,6 +22,7 @@
 - name: ANSISTRANO | Ensure basedir shared files exists
   file:
     state: directory
+    follow: yes
     path: "{{ ansistrano_deploy_to }}/shared/{{ item | dirname }}"
   with_items: "{{ ansistrano_shared_files }}"
 


### PR DESCRIPTION
this patch add ability to create in shared folder symlinks elsewhere in filesystem that will symlinked into release dir
for example 
ln -s /data ./shared/data
after ansistrano runs ./current/data will reference to ../../shared/data that reference to /data 
so ./current/data reference to /data

Works only on ansible >= 1.8