### PR TITLE
Ensure shared dirs exist during setup

### DIFF
--- a/tasks/setup.yml
+++ b/tasks/setup.yml
@@ -22,3 +22,17 @@
   file:
     state: directory
     path: "{{ ansistrano_shared_path.stdout }}"
+
+# Ensure shared path exists
+- name: ANSISTRANO | Ensure shared paths exists
+  file:
+    state: directory
+    path: "{{ ansistrano_deploy_to }}/shared/{{ item }}"
+  with_items: "{{ ansistrano_shared_paths }}"
+
+# Ensure basedir shared files exists
+- name: ANSISTRANO | Ensure basedir shared files exists
+  file:
+    state: directory
+    path: "{{ ansistrano_deploy_to }}/shared/{{ item | dirname }}"
+  with_items: "{{ ansistrano_shared_files }}"

--- a/tasks/symlink-shared.yml
+++ b/tasks/symlink-shared.yml
@@ -10,20 +10,6 @@
     - "{{ ansistrano_shared_paths }}"
     - "{{ ansistrano_shared_files }}"
 
-# Ensure shared path exists
-- name: ANSISTRANO | Ensure shared paths exists
-  file:
-    state: directory
-    path: "{{ ansistrano_deploy_to }}/shared/{{ item }}"
-  with_items: "{{ ansistrano_shared_paths }}"
-
-# Ensure basedir shared files exists
-- name: ANSISTRANO | Ensure basedir shared files exists
-  file:
-    state: directory
-    path: "{{ ansistrano_deploy_to }}/shared/{{ item | dirname }}"
-  with_items: "{{ ansistrano_shared_files }}"
-
 # Symlinks shared paths and files
 - name: ANSISTRANO | Create softlinks for shared paths and files
   file:


### PR DESCRIPTION
Related to #113 and #188. It sounds like you're aware of this issue and maybe you don't like this solution, but I figured I'd throw it to the wall and see if it sticks. For me, moving the dir creation to the setup step means that I can follow a pretty sensible deployment order:

1. I specify `ansistrano_shared_files: ["config/database.yml"]`
1. setup task creates `shared/config`
1. My after-setup task populates `shared/config/database.yml` with content, without needing to create the dir
1. symlink-shared task symlinks to this file, which will always exist by now