### PR TITLE
Rename sudo to become to avoid deprecation warnings

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -3,11 +3,13 @@ Vagrant.configure("2") do |config|
         config.vm.box = 'ubuntu/trusty64'
         config.vm.hostname = 'web01'
         config.vm.synced_folder '.', '/vagrant', disabled: true
+        config.vm.network :forwarded_port, guest: 22, host: 2230, id: "ssh", auto_correct: false
     end
 
     config.vm.define 'web02' do |config|
         config.vm.box = 'ubuntu/trusty64'
         config.vm.hostname = 'web02'
         config.vm.synced_folder '.', '/vagrant', disabled: true
+        config.vm.network :forwarded_port, guest: 22, host: 2231, id: "ssh", auto_correct: false
     end
 end

--- a/example/my-playbook/hosts
+++ b/example/my-playbook/hosts
@@ -1,2 +1,2 @@
-web01 ansible_user=vagrant ansible_port=2222 ansible_host=127.0.0.1 ansible_ssh_private_key_file=../../.vagrant/machines/web01/virtualbox/private_key
-web02 ansible_user=vagrant ansible_port=2200 ansible_host=127.0.0.1 ansible_ssh_private_key_file=../../.vagrant/machines/web02/virtualbox/private_key
+web01 ansible_user=vagrant ansible_port=2230 ansible_host=127.0.0.1 ansible_ssh_private_key_file=../../.vagrant/machines/web01/virtualbox/private_key
+web02 ansible_user=vagrant ansible_port=2231 ansible_host=127.0.0.1 ansible_ssh_private_key_file=../../.vagrant/machines/web02/virtualbox/private_key

--- a/tasks/anon-stats.yml
+++ b/tasks/anon-stats.yml
@@ -11,4 +11,4 @@
   run_once: true
   ignore_errors: yes
   delegate_to: 127.0.0.1
-  sudo: false
+  become: false


### PR DESCRIPTION
This will fix the deprecation warnings. We test against Ansible 1.9, so this should not be a problem. 

There is maybe just open question: We define Ansible 1.8 in the meta data, but we test against 1.9. What should be the minimum required version for Ansistrano? I think 1.9 is ok, because its the last of the 1.x branch and 2.x is there quiet a while. 

What do you think? 