### PR TITLE
Define the default ssh ports for testing

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -3,11 +3,13 @@ Vagrant.configure("2") do |config|
         config.vm.box = 'ubuntu/trusty64'
         config.vm.hostname = 'web01'
         config.vm.synced_folder '.', '/vagrant', disabled: true
+        config.vm.network :forwarded_port, guest: 22, host: 2230, id: "ssh", auto_correct: false
     end
 
     config.vm.define 'web02' do |config|
         config.vm.box = 'ubuntu/trusty64'
         config.vm.hostname = 'web02'
         config.vm.synced_folder '.', '/vagrant', disabled: true
+        config.vm.network :forwarded_port, guest: 22, host: 2231, id: "ssh", auto_correct: false
     end
 end

--- a/example/my-playbook/hosts
+++ b/example/my-playbook/hosts
@@ -1,2 +1,2 @@
-web01 ansible_user=vagrant ansible_port=2222 ansible_host=127.0.0.1 ansible_ssh_private_key_file=../../.vagrant/machines/web01/virtualbox/private_key
-web02 ansible_user=vagrant ansible_port=2200 ansible_host=127.0.0.1 ansible_ssh_private_key_file=../../.vagrant/machines/web02/virtualbox/private_key
+web01 ansible_user=vagrant ansible_port=2230 ansible_host=127.0.0.1 ansible_ssh_private_key_file=../../.vagrant/machines/web01/virtualbox/private_key
+web02 ansible_user=vagrant ansible_port=2231 ansible_host=127.0.0.1 ansible_ssh_private_key_file=../../.vagrant/machines/web02/virtualbox/private_key


### PR DESCRIPTION
This defines the default ssh ports for vagrant to rely on in the host file in the exapmle for testing. Without the definition, you never know the port where vagrant will connect the VM.