### PR TITLE
Rename sudo to become to avoid deprecation warnings

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -4,7 +4,7 @@ galaxy_info:
   description: Ansible role to deploy scripting applications like PHP, Python, Ruby, etc. in a Capistrano style
   company: Ansistrano
   license: MIT
-  min_ansible_version: 1.8
+  min_ansible_version: 1.9
   platforms:
   - name: EL
     versions:

--- a/tasks/anon-stats.yml
+++ b/tasks/anon-stats.yml
@@ -11,4 +11,4 @@
   run_once: true
   ignore_errors: yes
   delegate_to: 127.0.0.1
-  sudo: false
+  become: false


### PR DESCRIPTION
This will fix the deprecation warnings. We test against Ansible 1.9, so this should not be a problem.

There is maybe just open question: We define Ansible 1.8 in the meta data, but we test against 1.9. What should be the minimum required version for Ansistrano? I think 1.9 is ok, because its the last of the 1.x branch and 2.x is there quiet a while.

What do you think?