### PR TITLE
Make ansible-lint and best practices copliant

### DIFF
--- a/tasks/anon-stats.yml
+++ b/tasks/anon-stats.yml
@@ -11,4 +11,4 @@
   run_once: true
   ignore_errors: yes
   delegate_to: 127.0.0.1
-  sudo: false
+  become: false

--- a/tasks/rsync-deploy.yml
+++ b/tasks/rsync-deploy.yml
@@ -18,6 +18,8 @@
 
 - name: ANSISTRANO | Sync release to new current path
   command: rsync -a -F --no-times --delete-after "{{ ansistrano_release_path.stdout }}/" "{{ ansistrano_deploy_to }}/{{ ansistrano_current_dir }}/"
+  args:
+    creates: "{{ ansistrano_deploy_to }}/{{ ansistrano_current_dir }}/"
 
 # Ensure symlinks target paths is absent
 - name: ANSISTRANO | Ensure shared paths targets are absent

--- a/tasks/rsync-deploy.yml
+++ b/tasks/rsync-deploy.yml
@@ -17,9 +17,14 @@
     path: "{{ ansistrano_deploy_to }}/{{ ansistrano_current_dir }}"
 
 - name: ANSISTRANO | Sync release to new current path
-  command: rsync -a -F --no-times --delete-after "{{ ansistrano_release_path.stdout }}/" "{{ ansistrano_deploy_to }}/{{ ansistrano_current_dir }}/"
-  args:
-    creates: "{{ ansistrano_deploy_to }}/{{ ansistrano_current_dir }}/"
+  synchronize:
+    src: "{{ ansistrano_release_path.stdout }}/"
+    dest: "{{ ansistrano_deploy_to }}/{{ ansistrano_current_dir }}/"
+    recursive: yes
+    archive: yes
+    rsync_opts:
+      - "--no-times"
+      - "--delete-after"
 
 # Ensure symlinks target paths is absent
 - name: ANSISTRANO | Ensure shared paths targets are absent

--- a/tasks/rsync-deploy.yml
+++ b/tasks/rsync-deploy.yml
@@ -1,7 +1,6 @@
 ---
-
-# Migration check from symlink deployment
-- stat:
+- name: ANSISTRANO | Register stats for current dir
+  stat:
     path: "{{ ansistrano_deploy_to }}/{{ ansistrano_current_dir }}"
   register: stat_current_dir
 

--- a/tasks/setup.yml
+++ b/tasks/setup.yml
@@ -6,17 +6,14 @@
     path: "{{ ansistrano_deploy_to }}"
 
 - name: ANSISTRANO | Set releases path
-  command: echo "{{ ansistrano_deploy_to }}/{{ ansistrano_version_dir }}"
-  register: ansistrano_releases_path
-
-- name: ANSISTRANO | Ensure releases folder exists
-  file:
-    state: directory
-    path: "{{ ansistrano_releases_path.stdout }}"
+  set_fact:
+    ansistrano_releases_path:
+      stdout: "{{ ansistrano_deploy_to }}/{{ ansistrano_version_dir }}"
 
 - name: ANSISTRANO | Set shared path
-  command: echo "{{ ansistrano_deploy_to }}/shared"
-  register: ansistrano_shared_path
+  set_fact:
+    ansistrano_shared_path:
+      stdout: "{{ ansistrano_deploy_to }}/shared"
 
 - name: ANSISTRANO | Ensure shared elements folder exists
   file:

--- a/tasks/setup.yml
+++ b/tasks/setup.yml
@@ -10,6 +10,11 @@
     ansistrano_releases_path:
       stdout: "{{ ansistrano_deploy_to }}/{{ ansistrano_version_dir }}"
 
+- name: ANSISTRANO | Ensure releases folder exists
+  file:
+    state: directory
+    path: "{{ ansistrano_releases_path.stdout }}"
+
 - name: ANSISTRANO | Set shared path
   set_fact:
     ansistrano_shared_path:

--- a/tasks/symlink-shared.yml
+++ b/tasks/symlink-shared.yml
@@ -1,6 +1,6 @@
 ---
 # Ensure symlinks target paths is absent
-# This was removed in 1.7.3 to improve speed but it introduced regressions in cases where 
+# This was removed in 1.7.3 to improve speed but it introduced regressions in cases where
 # there are .gitkeep files in such folders (common practice in some PHP frameworks)
 - name: ANSISTRANO | Ensure shared paths targets are absent
   file:

--- a/tasks/symlink.yml
+++ b/tasks/symlink.yml
@@ -1,7 +1,6 @@
 ---
-
-# Migration check from rsync deployment
-- stat:
+- name: ANSISTRANO | Register stats for current dir
+  stat:
     path: "{{ ansistrano_deploy_to }}/{{ ansistrano_current_dir }}"
   register: stat_current_dir
 

--- a/tasks/update-code.yml
+++ b/tasks/update-code.yml
@@ -8,8 +8,9 @@
   delegate_to: 127.0.0.1
 
 - name: ANSISTRANO | Get release path
-  command: echo "{{ ansistrano_releases_path.stdout }}/{{ ansistrano_release_version }}"
-  register: ansistrano_release_path
+  set_fact:
+    ansistrano_release_path:
+      stdout: "{{ ansistrano_releases_path.stdout }}/{{ ansistrano_release_version }}"
 
 - include: "update-code/{{ ansistrano_deploy_via | default('rsync') }}.yml"
 

--- a/tasks/update-code/rsync.yml
+++ b/tasks/update-code/rsync.yml
@@ -1,7 +1,8 @@
 ---
 - name: ANSISTRANO | RSYNC | Get shared path (in rsync case)
-  command: echo "{{ ansistrano_shared_path.stdout }}/.shared-copy"
-  register: ansistrano_shared_rsync_copy_path
+  set_fact:
+    ansistrano_shared_rsync_copy_path:
+      stdout: "{{ ansistrano_shared_path.stdout }}/.shared-copy"
 
 - name: ANSISTRANO | RSYNC | Rsync application files to remote shared copy
   synchronize:

--- a/tasks/update-code/rsync.yml
+++ b/tasks/update-code/rsync.yml
@@ -17,3 +17,5 @@
 
 - name: ANSISTRANO | RSYNC | Deploy existing code to servers
   command: cp -a {{ ansistrano_shared_rsync_copy_path.stdout }} {{ ansistrano_release_path.stdout }}
+  args:
+    creates: ansistrano_release_path.stdout


### PR DESCRIPTION
[Ansible-lint](https://github.com/willthames/ansible-lint) checks playbooks for practices and behavior that could potentially be improved. We have some bad habits in the code which we can make better:

1) **Use echo to register variables**: We should replace this wit _set_fact_. The problem here is, that we use the _.stdout_ over and over. So i register it as a dict, but that's only for BC compatibility. We should change this to a version without _.stdout_ in a future version. 

2) **Use synchronize instead of rsync in a command**: I'm not sure if this is working. @mblaschke removed synchronize some time ago and replaced it with the plain rsync call. It would be great if you have a look at this and give some feedback to this issue.  

3) Use the creates argument when using a command. 

4) Some minor tasks like whitespace, missing names and deprecated sudo instead of become.

What do you think about this improvements? Please provide some feedback so we can make Ansistrano even better :-) 