### PR TITLE
Makes optional shared paths and basedir shared files creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,8 +147,8 @@ Role Variables
 
   # Shared paths and basedir shared files creation.
   # By default the shared paths directories and base directories for shared files are created automatically if not exists. But in some scenarios those paths could be symlinks to another directories in the filesystem, and the deployment process would fails. With these variables you can disable the involved tasks. If you have two or three shared paths, and don't need creation only for some of them, you always could disable the automatic creation and add a custom task in a hook.
-  ansistrano_ensure_shared_paths_exists: yes
-  ansistrano_ensure_basedir_shared_files_exists: yes
+  ansistrano_ensure_shared_paths_exist: yes
+  ansistrano_ensure_basedirs_shared_files_exist: yes
 
   ansistrano_deploy_via: "rsync" # Method used to deliver the code to the server. Options are copy, rsync, git, svn, s3 or download. Copy, download and s3 have an optional step to unarchive the downloaded file which can be used by adding _unarchive. You can check all the options inside tasks/update-code folder!
   ansistrano_allow_anonymous_stats: yes

--- a/README.md
+++ b/README.md
@@ -144,6 +144,12 @@ Role Variables
   ansistrano_shared_paths: []
   ansistrano_shared_files: []
   
+
+  # Shared paths and basedir shared files creation.
+  # By default the shared paths directories and base directories for shared files are created automatically if not exists. But in some scenarios those paths could be symlinks to another directories in the filesystem, and the deployment process would fails. With these variables you can disable the involved tasks. If you have two or three shared paths, and don't need creation only for some of them, you always could disable the automatic creation and add a custom task in a hook.
+  ansistrano_ensure_shared_paths_exists: yes
+  ansistrano_ensure_basedir_shared_files_exists: yes
+
   ansistrano_deploy_via: "rsync" # Method used to deliver the code to the server. Options are copy, rsync, git, svn, s3 or download. Copy, download and s3 have an optional step to unarchive the downloaded file which can be used by adding _unarchive. You can check all the options inside tasks/update-code folder!
   ansistrano_allow_anonymous_stats: yes
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -26,6 +26,10 @@ ansistrano_shared_paths: []
 # Shared files to symlink to release dir
 ansistrano_shared_files: []
 
+# Shared paths and basedir shared files creation
+ansistrano_ensure_shared_paths_exists: yes
+ansistrano_ensure_basedir_shared_files_exists: yes
+
 # Number of releases to keep in your hosts, if 0, unlimited releases will be kept
 ansistrano_keep_releases: 0
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -27,8 +27,8 @@ ansistrano_shared_paths: []
 ansistrano_shared_files: []
 
 # Shared paths and basedir shared files creation
-ansistrano_ensure_shared_paths_exists: yes
-ansistrano_ensure_basedir_shared_files_exists: yes
+ansistrano_ensure_shared_paths_exist: yes
+ansistrano_ensure_basedirs_shared_files_exist: yes
 
 # Number of releases to keep in your hosts, if 0, unlimited releases will be kept
 ansistrano_keep_releases: 0

--- a/tasks/setup.yml
+++ b/tasks/setup.yml
@@ -21,6 +21,7 @@
     state: directory
     path: "{{ ansistrano_deploy_to }}/shared/{{ item }}"
   with_items: "{{ ansistrano_shared_paths }}"
+  when: ansistrano_ensure_shared_paths_exists
 
 # Ensure basedir shared files exists
 - name: ANSISTRANO | Ensure basedir shared files exists
@@ -28,3 +29,4 @@
     state: directory
     path: "{{ ansistrano_deploy_to }}/shared/{{ item | dirname }}"
   with_items: "{{ ansistrano_shared_files }}"
+  when: ansistrano_ensure_basedir_shared_files_exists

--- a/tasks/setup.yml
+++ b/tasks/setup.yml
@@ -21,7 +21,7 @@
     state: directory
     path: "{{ ansistrano_deploy_to }}/shared/{{ item }}"
   with_items: "{{ ansistrano_shared_paths }}"
-  when: ansistrano_ensure_shared_paths_exists
+  when: ansistrano_ensure_shared_paths_exist
 
 # Ensure basedir shared files exists
 - name: ANSISTRANO | Ensure basedir shared files exists
@@ -29,4 +29,4 @@
     state: directory
     path: "{{ ansistrano_deploy_to }}/shared/{{ item | dirname }}"
   with_items: "{{ ansistrano_shared_files }}"
-  when: ansistrano_ensure_basedir_shared_files_exists
+  when: ansistrano_ensure_basedirs_shared_files_exist


### PR DESCRIPTION
Hi! I've updated ansistrano from an old version, and the project deployment has failed.

After investigating the problem, I've found a couple of tasks that were added in #142 to prepare shared folders before symlinking. It also makes sense for most of our projects and environments, but in a node from a particular client, the `state: directory` causes the task fails because the path exists as a symlink to another directory in the filesystem.

I think it could be good to make these tasks optional, enabled via ansible defaults, but overridable by the user. For now that approach is working for us.