### PR TITLE
Update cleanup.yml

### DIFF
--- a/tasks/cleanup.yml
+++ b/tasks/cleanup.yml
@@ -3,3 +3,4 @@
 - name: ANSISTRANO | Clean up releases
   shell: ls -1dt {{ ansistrano_releases_path }}/* | tail -n +{{ ansistrano_keep_releases | int + 1 }} | xargs rm -rf
   when: ansistrano_keep_releases > 0
+  become: true


### PR DESCRIPTION
When deploying using a non-privileged user, clean-up process could fail in case read-only files need to be deleted.
Most of the web applications have read-only configuration files.