### PR TITLE
Adding support for symlinked shared files and directories

### DIFF
--- a/tasks/setup.yml
+++ b/tasks/setup.yml
@@ -8,17 +8,20 @@
 - name: ANSISTRANO | Ensure releases folder exists
   file:
     state: directory
+    follow: true
     path: "{{ ansistrano_releases_path }}"
 
 - name: ANSISTRANO | Ensure shared elements folder exists
   file:
     state: directory
+    follow: true
     path: "{{ ansistrano_shared_path }}"
 
 # Ensure shared path exists
 - name: ANSISTRANO | Ensure shared paths exists
   file:
     state: directory
+    follow: true
     path: "{{ ansistrano_deploy_to }}/shared/{{ item }}"
   with_items: "{{ ansistrano_shared_paths }}"
   when: ansistrano_ensure_shared_paths_exist
@@ -27,6 +30,7 @@
 - name: ANSISTRANO | Ensure basedir shared files exists
   file:
     state: directory
+    follow: true
     path: "{{ ansistrano_deploy_to }}/shared/{{ item | dirname }}"
   with_items: "{{ ansistrano_shared_files }}"
   when: ansistrano_ensure_basedirs_shared_files_exist


### PR DESCRIPTION
Hello!
I think that shared files and directories can be symlinked. For example, I had to make them symlinked while setting up Ansistrano for a deployed production project.
But if shared files are symlinked 'ANSISTRANO | Ensure shared paths exists' step would fail with "directory already exists as link error". So, I propose to add "follow: true" option to checking shared files and paths steps.