### PR TITLE
Add Moss as a product using Ansistrano

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Is Ansistrano ready to be used? Here are some companies currently using it:
 * [Holaluz](https://www.holaluz.com)
 * [Jolicode](http://jolicode.com/)
 * [Kidfund](http://link.kidfund.us/github "Kidfund")
+* [Moss](https://moss.sh)
 * [Nice&Crazy](http://www.niceandcrazy.com)
 * [Nodo Ámbar](http://www.nodoambar.com/)
 * [Oferplan](http://oferplan.com/)


### PR DESCRIPTION
Hi!

In Doalitic we developed [Moss](https://moss.sh), a Sysadmin-as-a-Service, and we are using Ansistrano to deploy sites to servers.

We are very happy with the impressive work you've done, thanks! 😀 

This PR adds Moss to the list of products/companies using Ansistrano.