### PR TITLE
workaround rsync quoting bug

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -59,7 +59,7 @@ ansistrano_hg_repo: "https://USERNAME@bitbucket.org/USERNAME/REPO"
 ansistrano_hg_branch: "default"
 
 ## RSYNC push strategy
-ansistrano_rsync_extra_params: ""
+# ansistrano_rsync_extra_params: ""
 ## put user@ for the remote paths. If you have a custom ssh config to define
 ## the remote user for a host that does not match the inventory user,
 ## you should set this parameter to "no".

--- a/tasks/update-code/rsync.yml
+++ b/tasks/update-code/rsync.yml
@@ -12,7 +12,7 @@
     delete: yes
     archive: yes
     compress: yes
-    rsync_opts: "{{ ansistrano_rsync_extra_params }}"
+    rsync_opts: "{{ ansistrano_rsync_extra_params | default(omit) }}"
     rsync_path: "{{ ansistrano_rsync_path | default(omit) }}"
 
 - name: ANSISTRANO | RSYNC | Deploy existing code to servers


### PR DESCRIPTION
In Ansible 2.3, the way the rsync command line is built changed (see
ansible/ansible#23575), which caused the default empty string not to be
stripped, but included in the command. This in turn caused rsync to
always include the current working directory as source (As this is what
an empty argument apparently resolves to).

This workaround removes the default setting and adds a filter that omits
the parameter if it's not defined.

Fixes #227 and related.