### PR TITLE
Fixed shared paths location to use ansistrano_shared_path variable.

### DIFF
--- a/tasks/setup.yml
+++ b/tasks/setup.yml
@@ -19,7 +19,7 @@
 - name: ANSISTRANO | Ensure shared paths exists
   file:
     state: directory
-    path: "{{ ansistrano_deploy_to }}/shared/{{ item }}"
+    path: "{{ ansistrano_shared_path }}/{{ item }}"
   with_items: "{{ ansistrano_shared_paths }}"
   when: ansistrano_ensure_shared_paths_exist
 

--- a/tasks/symlink-shared.yml
+++ b/tasks/symlink-shared.yml
@@ -15,7 +15,7 @@
   file:
     state: link
     path: "{{ ansistrano_release_path.stdout }}/{{ item }}"
-    src: "{{ item | regex_replace('[^\\/]*', '..') }}/../shared/{{ item }}"
+    src: "{{ ansistrano_shared_path }}/{{ item }}"
   with_flattened:
     - "{{ ansistrano_shared_paths }}"
     - "{{ ansistrano_shared_files }}"


### PR DESCRIPTION
It is backward compatible change as default value for `ansistrano_shared_path` is "{{ ansistrano_deploy_to }}/shared". The only difference is that now symlinks to shared files will be absolute instead of relative.