### PR TITLE
Correct symlinks via rsync

### DIFF
--- a/tasks/rsync-deploy.yml
+++ b/tasks/rsync-deploy.yml
@@ -25,7 +25,9 @@
   file:
     state: absent
     path: "{{ ansistrano_deploy_to }}/{{ ansistrano_current_dir }}/{{ item }}"
-  with_items: "{{ ansistrano_shared_paths }}"
+  with_flattened:
+    - "{{ ansistrano_shared_paths }}"
+    - "{{ ansistrano_shared_files }}"
 
 # Symlinks shared paths
 - name: ANSISTRANO | Create softlinks for shared paths
@@ -33,4 +35,6 @@
     state: link
     path: "{{ ansistrano_deploy_to }}/{{ ansistrano_current_dir }}/{{ item }}"
     src: "{{ item | regex_replace('[^\\/]*', '..') }}/shared/{{ item }}"
-  with_items: "{{ ansistrano_shared_paths }}"
+  with_flattened:
+    - "{{ ansistrano_shared_paths }}"
+    - "{{ ansistrano_shared_files }}"

--- a/tasks/symlink-shared.yml
+++ b/tasks/symlink-shared.yml
@@ -33,5 +33,7 @@
     dest: "{{ ansistrano_release_path.stdout }}/.rsync-filter"
     line: "- /{{ item }}"
     create: yes
-  with_items: "{{ ansistrano_shared_paths }}"
+  with_flattened:
+    - "{{ ansistrano_shared_paths }}"
+    - "{{ ansistrano_shared_files }}"
   when: ansistrano_current_via == "rsync"


### PR DESCRIPTION
This fixes the broken shared file symlinks of rsynced deployment. Current build creates shared file symlinks pointing to files in ../../shared on rsynced deployment but it should point to ../shared instead.