### PR TITLE
Add variable to deliver git identity key as string

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,18 @@ vars:
   ansistrano_git_repo: git@github.com:USERNAME/REPO.git # Location of the git repository
   ansistrano_git_branch: master # What version of the repository to check out. This can be the full 40-character SHA-1 hash, the literal string HEAD, a branch name, or a tag name
   ansistrano_git_repo_tree: "" # If specified the subtree of the repository to deploy
-  ansistrano_git_identity_key_path: "" # If specified this file is copied over and used as the identity key for the git commands, path is relative to the playbook in which it is used
+  # If either ansistrano_git_identity_key_path and ansistrano_git_identity_key_content is specified,
+  # a deployment key is is delivered just-in-time and used as the identity key for git commands.
+  # The variables are mutually exclusive.
+  # Use one or the other; using both causes ansistrano_git_identity_key_content to prevail
+  # The remote file is shred'd after each deploy.
+  # 
+  # Example: "secret-deploy-key.pem": path is relative to the playbook in which it is used
+  ansistrano_git_identity_key_path: "" 
+  # Example: "{{ lookup('file', '/Users/<username>/secret-deploy-key.pem') }}": pipe a local file to the remote host
+  # Example: "{{ vault_git_deployment_key }}": insert the contents of a variable as the deployment key
+  ansistrano_git_identity_key_content: ""
+
   # Optional variable, omitted by default
   ansistrano_git_refspec: ADDITIONAL_GIT_REFSPEC # Additional refspec to be used by the 'git' module. Uses the same syntax as the 'git fetch' command.
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -45,6 +45,7 @@ ansistrano_git_repo: git@github.com:USERNAME/REPO.git
 ansistrano_git_branch: master
 ansistrano_git_repo_tree: ""
 ansistrano_git_identity_key_path: ""
+ansistrano_git_identity_key_content: ""
 
 ## SVN pull strategy
 ansistrano_svn_repo: "https://svn.company.com/project"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -44,7 +44,17 @@ ansistrano_keep_releases: 0
 ansistrano_git_repo: git@github.com:USERNAME/REPO.git
 ansistrano_git_branch: master
 ansistrano_git_repo_tree: ""
-ansistrano_git_identity_key_path: ""
+# GIT strategy using SSH key
+# If either ansistrano_git_identity_key_path and ansistrano_git_identity_key_content is specified,
+# a deployment key is is delivered just-in-time and used as the identity key for git commands.
+# The variables are mutually exclusive.
+# Use one or the other; using both causes ansistrano_git_identity_key_content to prevail
+# The remote file is shred'd after each deploy.
+#
+# Example: "secret-deploy-key.pem": path is relative to the playbook in which it is used
+ansistrano_git_identity_key_path: "" 
+# Example: "{{ lookup('file', '/Users/<username>/secret-deploy-key.pem') }}": pipe a local file to the remote host
+# Example: "{{ vault_git_deployment_key }}": insert the contents of a variable as the deployment key
 ansistrano_git_identity_key_content: ""
 
 ## SVN pull strategy

--- a/tasks/update-code/git.yml
+++ b/tasks/update-code/git.yml
@@ -1,10 +1,22 @@
 ---
-- name: ANSISTRANO | GIT | Ensure GIT deployment key is up to date
+# Ansible in English:
+# Inspect two variables for a non-empty value, then omit opposite the module parameter.
+- name: ANSISTRANO | GIT | Deliver SSH deployment key
   copy:
-    src: "{{ ansistrano_git_identity_key_path }}"
+    content: "{{ (item.key == 'content')|ternary(item.value, omit) }}"
+    src: "{{ (item.key == 'src')|ternary(item.value, omit) }}"
     dest: "{{ ansistrano_deploy_to }}/git_identity_key"
     mode: 0400
-  when: ansistrano_git_identity_key_path|trim != ""
+  no_log: True
+  with_dict:
+    src: "{{ ansistrano_git_identity_key_path }}"
+    content: "{{ ansistrano_git_identity_key_content }}"
+  when: item.value|trim != ""
+
+- name: ANSISTRANO | GIT | Detect SSH key for deployment
+  stat:
+    path: "{{ ansistrano_deploy_to }}/git_identity_key"
+  register: ansistrano_git_ssh_key
 
 - name: ANSISTRANO | GIT | Update remote repository
   git:
@@ -16,7 +28,7 @@
     force: yes
     refspec: "{{ ansistrano_git_refspec | default(omit) }}"
   register: ansistrano_git_result_update
-  when: ansistrano_git_identity_key_path|trim == ''
+  when: ansistrano_git_ssh_key.stat.exists != True
 
 - name: ANSISTRANO | GIT | Update remote repository using SSH key
   git:
@@ -29,14 +41,14 @@
     refspec: "{{ ansistrano_git_refspec | default(omit) }}"
     key_file: "{{ ansistrano_deploy_to }}/git_identity_key"
   register: ansistrano_git_result_update_ssh
-  when: ansistrano_git_identity_key_path|trim != ""
+  when: ansistrano_git_ssh_key.stat.exists
 
 - name: ANSISTRANO | GIT | Register ansistrano_git_result variable
   set_fact: ansistrano_git_result={{ ansistrano_git_result_update_ssh if ansistrano_git_result_update|skipped else ansistrano_git_result_update }}
 
 - name: ANSISTRANO | GIT | Shred GIT deployment key
-  command: shred -f "{{ ansistrano_deploy_to }}/git_identity_key"
-  when: ansistrano_git_identity_key_path|trim != ""
+  command: shred -f -u "{{ ansistrano_deploy_to }}/git_identity_key"
+  when: ansistrano_git_ssh_key.stat.exists
 
 - name: ANSISTRANO | GIT | Set git_real_repo_tree
   set_fact:


### PR DESCRIPTION
We're users of Ansible Vault and store the deployment identity key as a string in a vault file, not a discrete file in an Ansible role (encrypted or not). This proposed change handles the case where the keys are delivered as a string, and not copied over as a file.

My proposed solution may not be optimal: adding a new var which behaves slightly different than the existing var isn't ideal. I'm open to help find a better solution.

One commit makes the change; another adds documentation and new examples for use cases.

Related PRs I'm aware of include 
#203 
#85 