### PR TITLE
Replace now deprecated include with import_tasks

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,36 +1,36 @@
 ---
-- include: "{{ ansistrano_before_setup_tasks_file | default('empty.yml') }}"
+- import_tasks: "{{ ansistrano_before_setup_tasks_file | default('empty.yml') }}"
 
-- include: setup.yml
+- import_tasks: setup.yml
 
-- include: "{{ ansistrano_after_setup_tasks_file | default('empty.yml') }}"
+- import_tasks: "{{ ansistrano_after_setup_tasks_file | default('empty.yml') }}"
 
-- include: "{{ ansistrano_before_update_code_tasks_file | default('empty.yml') }}"
+- import_tasks: "{{ ansistrano_before_update_code_tasks_file | default('empty.yml') }}"
 
-- include: update-code.yml
+- import_tasks: update-code.yml
 
-- include: "{{ ansistrano_after_update_code_tasks_file | default('empty.yml') }}"
+- import_tasks: "{{ ansistrano_after_update_code_tasks_file | default('empty.yml') }}"
 
-- include: "{{ ansistrano_before_symlink_shared_tasks_file | default('empty.yml') }}"
+- import_tasks: "{{ ansistrano_before_symlink_shared_tasks_file | default('empty.yml') }}"
 
-- include: symlink-shared.yml
+- import_tasks: symlink-shared.yml
 
-- include: "{{ ansistrano_after_symlink_shared_tasks_file | default('empty.yml') }}"
+- import_tasks: "{{ ansistrano_after_symlink_shared_tasks_file | default('empty.yml') }}"
 
-- include: "{{ ansistrano_before_symlink_tasks_file | default('empty.yml') }}"
+- import_tasks: "{{ ansistrano_before_symlink_tasks_file | default('empty.yml') }}"
 
-- include: symlink.yml
+- import_tasks: symlink.yml
   when: ansistrano_current_via == "symlink"
 
-- include: rsync-deploy.yml
+- import_tasks: rsync-deploy.yml
   when: ansistrano_current_via == "rsync"
 
-- include: "{{ ansistrano_after_symlink_tasks_file | default('empty.yml') }}"
+- import_tasks: "{{ ansistrano_after_symlink_tasks_file | default('empty.yml') }}"
 
-- include: "{{ ansistrano_before_cleanup_tasks_file | default('empty.yml') }}"
+- import_tasks: "{{ ansistrano_before_cleanup_tasks_file | default('empty.yml') }}"
 
-- include: cleanup.yml
+- import_tasks: cleanup.yml
 
-- include: "{{ ansistrano_after_cleanup_tasks_file | default('empty.yml') }}"
+- import_tasks: "{{ ansistrano_after_cleanup_tasks_file | default('empty.yml') }}"
 
-- include: anon-stats.yml
+- import_tasks: anon-stats.yml

--- a/tasks/update-code.yml
+++ b/tasks/update-code.yml
@@ -11,7 +11,7 @@
   command: echo "{{ ansistrano_releases_path }}/{{ ansistrano_release_version }}"
   register: ansistrano_release_path
 
-- include: "update-code/{{ ansistrano_deploy_via | default('rsync') }}.yml"
+- import_tasks: "update-code/{{ ansistrano_deploy_via | default('rsync') }}.yml"
 
 - name: ANSISTRANO | Copy release version into REVISION file
   copy:

--- a/tasks/update-code/copy_unarchive.yml
+++ b/tasks/update-code/copy_unarchive.yml
@@ -1,8 +1,8 @@
 ---
-- include: copy.yml
+- import_tasks: copy.yml
 
 - name: ANSISTRANO | copy_unarchive | Set archived file
   set_fact:
     ansistrano_archived_file: "{{ ansistrano_release_path.stdout }}/{{ ansistrano_deploy_from | basename }}"
 
-- include: unarchive.yml
+- import_tasks: unarchive.yml

--- a/tasks/update-code/download_unarchive.yml
+++ b/tasks/update-code/download_unarchive.yml
@@ -1,8 +1,8 @@
 ---
-- include: download.yml
+- import_tasks: download.yml
 
 - name: ANSISTRANO | download_unarchive | Set archived file
   set_fact:
     ansistrano_archived_file: "{{ ansistrano_release_path.stdout }}/{{ ansistrano_get_url | basename }}"
 
-- include: unarchive.yml
+- import_tasks: unarchive.yml

--- a/tasks/update-code/s3_unarchive.yml
+++ b/tasks/update-code/s3_unarchive.yml
@@ -1,8 +1,8 @@
 ---
-- include: s3.yml
+- import_tasks: s3.yml
 
 - name: ANSISTRANO | s3_unarchive | Set archived file
   set_fact:
     ansistrano_archived_file: "{{ ansistrano_release_path.stdout }}/{{ ansistrano_s3_object | basename }}"
 
-- include: unarchive.yml
+- import_tasks: unarchive.yml

--- a/test/main.yml
+++ b/test/main.yml
@@ -1,7 +1,7 @@
 ---
-- include: setup.yml
-- include: rsync.yml
-- include: git.yml
-- include: download.yml
-- include: svn.yml
-- include: hg.yml
+- import_tasks: setup.yml
+- import_tasks: rsync.yml
+- import_tasks: git.yml
+- import_tasks: download.yml
+- import_tasks: svn.yml
+- import_tasks: hg.yml


### PR DESCRIPTION
**NOTE:** imposes a new requirement for ansible version to be at least 2.4.