### PR TITLE
use ansistrano_shared_path varaible on setup task

### DIFF
--- a/tasks/setup.yml
+++ b/tasks/setup.yml
@@ -19,7 +19,7 @@
 - name: ANSISTRANO | Ensure shared paths exists
   file:
     state: directory
-    path: "{{ ansistrano_deploy_to }}/shared/{{ item }}"
+    path: "{{ ansistrano_shared_path }}/{{ item }}"
   with_items: "{{ ansistrano_shared_paths }}"
   when: ansistrano_ensure_shared_paths_exist
 
@@ -27,6 +27,6 @@
 - name: ANSISTRANO | Ensure basedir shared files exists
   file:
     state: directory
-    path: "{{ ansistrano_deploy_to }}/shared/{{ item | dirname }}"
+    path: "{{ ansistrano_shared_path }}/{{ item | dirname }}"
   with_items: "{{ ansistrano_shared_files }}"
   when: ansistrano_ensure_basedirs_shared_files_exist


### PR DESCRIPTION
ansistrano_shared_path is create but note use on all playbook role.

Add this variable on the setup task for create shared basedir