### PR TITLE
Use hard links to avoid duplicates between releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ vars:
   ansistrano_current_dir: "current" # Softlink name. You should rarely changed it.
   ansistrano_current_via: "symlink" # Deployment strategy who code should be deployed to current path. Options are symlink or rsync
   ansistrano_keep_releases: 0 # Releases to keep after a new deployment. See "Pruning old releases".
+  ansistrano_use_hardlinks: no # If your system allows it, you can save you a lot of space by using hard links.
 
   # Arrays of directories and files to be shared.
   # The following arrays of directories and files will be symlinked to the current release directory after the 'update-code' step and its callbacks
@@ -397,6 +398,13 @@ Let's see three deployments with an `ansistrano_keep_releases: 2` configuration:
 ```
 
 See how the release `20100509145325` has been removed.
+
+Additionally, you can save tons of space by using hard links instead of having duplicate files between releases.
+Just set `ansistrano_use_hardlinks` to `yes`. 
+
+Not fully tested. Today only works with `ansistrano_deploy_via: "rsync"`. 
+Check if your system supports `cp -l` and your filesystem supports hard links, like `ext2/3/4`. 
+Not useful if your filesystem already has _Data deduplication_, like `ZFS` or `Btrfs`. 
 
 Example Playbook
 ----------------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -33,6 +33,9 @@ ansistrano_ensure_basedirs_shared_files_exist: yes
 # Number of releases to keep in your hosts, if 0, unlimited releases will be kept
 ansistrano_keep_releases: 0
 
+# Use hard links between releases to save space
+ansistrano_use_hardlinks: no
+
 # Deployment strategies variables
 
 # Due to runtime variable evaluation, the ansistrano_deploy_via default is actually

--- a/tasks/update-code/rsync.yml
+++ b/tasks/update-code/rsync.yml
@@ -17,3 +17,8 @@
 
 - name: ANSISTRANO | RSYNC | Deploy existing code to servers
   command: cp -a {{ ansistrano_shared_rsync_copy_path.stdout }} {{ ansistrano_release_path.stdout }}
+  when: not ansistrano_use_hardlinks
+
+- name: ANSISTRANO | RSYNC | Deploy existing code to servers (using hard links)
+  command: cp -al {{ ansistrano_shared_rsync_copy_path.stdout }} {{ ansistrano_release_path.stdout }}
+  when: ansistrano_use_hardlinks


### PR DESCRIPTION
At present it's only implemented for 'rsync'.
I've also added a boolean in config, and updated the readme.