### PR TITLE
277 revision file copy operation fails with unprivileged user

### DIFF
--- a/README.md
+++ b/README.md
@@ -477,7 +477,7 @@ skipping: [quepimquepam.com]
 TASK: [carlosbuenosvinos.ansistrano-deploy | Deploy code from to servers] *****
 skipping: [quepimquepam.com]
 
-TASK: [carlosbuenosvinos.ansistrano-deploy | Copy release version into REVISION file] ***
+TASK: [carlosbuenosvinos.ansistrano-deploy | Create REVISION file containing release version] ***
 changed: [quepimquepam.com]
 
 TASK: [carlosbuenosvinos.ansistrano-deploy | Touches up the release code] *****

--- a/tasks/update-code.yml
+++ b/tasks/update-code.yml
@@ -15,6 +15,6 @@
 
 - name: ANSISTRANO | Create REVISION file containing release version
   lineinfile:
-    path: "{{ ansistrano_release_path.stdout }}/REVISION"
+    dest: "{{ ansistrano_release_path.stdout }}/REVISION"
     line: "{{ ansistrano_release_version }}"
     create: true

--- a/tasks/update-code.yml
+++ b/tasks/update-code.yml
@@ -13,7 +13,8 @@
 
 - include: "update-code/{{ ansistrano_deploy_via | default('rsync') }}.yml"
 
-- name: ANSISTRANO | Copy release version into REVISION file
-  copy:
-    content: "{{ ansistrano_release_version }}"
-    dest: "{{ ansistrano_release_path.stdout }}/REVISION"
+- name: ANSISTRANO | Create REVISION file containing release version
+  lineinfile:
+    path: "{{ ansistrano_release_path.stdout }}/REVISION"
+    line: "{{ ansistrano_release_version }}"
+    create: true


### PR DESCRIPTION
This PR replaces the `update-code.yml` file's `REVISION`-file creating `copy` operation with a `lineinfile` operation (and updates the README's sample output) to prevent the role from failing when used by unprivileged users.

As far as I'm able to determine, this has no ill effects.
  