### PR TITLE
MEDIA.figaro user

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ Is Ansistrano ready to be used? Here are some companies currently using it:
 * [Hosting4devs](https://hosting4devs.com)
 * [Jolicode](http://jolicode.com/)
 * [Kidfund](http://link.kidfund.us/github "Kidfund")
+* [MEDIA.figaro](http://media.figaro.fr)
 * [Moss](https://moss.sh)
 * [Nice&Crazy](http://www.niceandcrazy.com)
 * [Nodo Ámbar](http://www.nodoambar.com/)


### PR DESCRIPTION
We use it too, thanks for the excellent work. We've been using Capistrano for a time and Ansible for server setups but now we are using Ansistrano for Symfony 4 deployments. MEDIA.figaro ([media.figaro.fr](http://media.figaro.fr)) is the advertisement department of one of the main french newspaper Le Figaro (www.lefigaro.fr). Best, Kendrick (www.kendrick.it).