### PR TITLE
symlink-shared use force option. to allow link target not exists

### DIFF
--- a/tasks/symlink-shared.yml
+++ b/tasks/symlink-shared.yml
@@ -16,6 +16,7 @@
     state: link
     path: "{{ ansistrano_release_path.stdout }}/{{ item }}"
     src: "{{ item | regex_replace('[^\\/]*', '..') }}/../shared/{{ item }}"
+    force: yes
   with_flattened:
     - "{{ ansistrano_shared_paths }}"
     - "{{ ansistrano_shared_files }}"


### PR DESCRIPTION
if ansistrano_ensure_basedirs_shared_files_exist=yes and target file no exists, the deplyment always fail
if ansistrano_ensure_basedirs_shared_files_exist=no and target file no exists. the deplyment fail too. :-(
