### PR TITLE
Add rsync_unarchive update-code option

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ vars:
   ansistrano_ensure_shared_paths_exist: yes
   ansistrano_ensure_basedirs_shared_files_exist: yes
 
-  ansistrano_deploy_via: "rsync" # Method used to deliver the code to the server. Options are copy, rsync, git, svn, s3 or download. Copy, download and s3 have an optional step to unarchive the downloaded file which can be used by adding _unarchive. You can check all the options inside tasks/update-code folder!
+  ansistrano_deploy_via: "rsync" # Method used to deliver the code to the server. Options are copy, rsync, git, svn, s3 or download. Copy, rsync, download and s3 have an optional step to unarchive the downloaded file which can be used by adding _unarchive. You can check all the options inside tasks/update-code folder!
   ansistrano_allow_anonymous_stats: yes
 
   # Variables used in the rsync deployment strategy

--- a/tasks/update-code/rsync_unarchive.yml
+++ b/tasks/update-code/rsync_unarchive.yml
@@ -1,0 +1,39 @@
+---
+- name: ANSISTRANO | RSYNC | Get shared path (in rsync case)
+  command: echo "{{ ansistrano_shared_path }}/.shared-copy"
+  register: ansistrano_shared_rsync_copy_path
+
+- name: ANSISTRANO | RSYNC | Get Archive filepath (in rsync case)
+  command: echo "{{ ansistrano_shared_path }}/{{ ansistrano_deploy_from | basename }}"
+  register: ansistrano_rsync_file_path
+
+- name: ANSISTRANO | RSYNC | Rsync application files to remote shared copy
+  synchronize:
+    src: "{{ ansistrano_deploy_from }}"
+    dest: "{{ ansistrano_rsync_file_path.stdout }}"
+    set_remote_user: "{{ ansistrano_rsync_set_remote_user }}"
+    recursive: yes
+    delete: yes
+    archive: yes
+    compress: yes
+    rsync_opts: "{{ ansistrano_rsync_extra_params | default(omit) }}"
+    rsync_path: "{{ ansistrano_rsync_path | default(omit) }}"
+
+- name: ANSISTRANO | RSYNC_UNARCHIVE | Create release folder
+  file:
+    state: directory
+    path: "{{ ansistrano_shared_rsync_copy_path.stdout }}"
+
+- name: ANSISTRANO | Unarchive | Unarchive source
+  unarchive:
+    copy: no
+    src: "{{ ansistrano_rsync_file_path.stdout }}"
+    dest: "{{ ansistrano_shared_rsync_copy_path.stdout }}"
+
+- name: ANSISTRANO | Unarchive | Delete archived file
+  file:
+    path: "{{ ansistrano_rsync_file_path.stdout }}"
+    state: absent
+
+- name: ANSISTRANO | RSYNC | Deploy existing code to servers
+  command: cp -a {{ ansistrano_shared_rsync_copy_path.stdout }} {{ ansistrano_release_path.stdout }}


### PR DESCRIPTION
This adds an option to deploy a pre-build package of your code to the remote servers using rsync, unarchive it, and use it to deploy the application.

Option name: `ansistrano_deploy_via: "rsync_unarchive"`

To specify the deploy package:
`ansistrano_deploy_from: "{{ playbook_dir }}/../deploy_package.tar.gz"`

This option is needed because we use a CI tool to generate all dependencies for our project, package everything and deploy this package.

This makes it very useful to re-use the deploy packages.