### PR TITLE
Adding feature to give a custom name to the checked out site repository.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -40,6 +40,9 @@ ansistrano_keep_releases: 0
 # playbook as needed.
 # ansistrano_deploy_via: "rsync"
 
+# Directory name for the checked out repository
+ansistrano_repo_dir: "repo"
+
 ## GIT pull strategy
 ansistrano_git_repo: git@github.com:USERNAME/REPO.git
 ansistrano_git_branch: master

--- a/tasks/update-code/git.yml
+++ b/tasks/update-code/git.yml
@@ -17,7 +17,7 @@
 - name: ANSISTRANO | GIT | Update remote repository
   git:
     repo: "{{ ansistrano_git_repo }}"
-    dest: "{{ ansistrano_deploy_to }}/repo"
+    dest: "{{ ansistrano_deploy_to }}/{{ ansistrano_repo_dir }}"
     version: "{{ ansistrano_git_branch }}"
     accept_hostkey: true
     update: yes
@@ -31,7 +31,7 @@
 - name: ANSISTRANO | GIT | Update remote repository using SSH key
   git:
     repo: "{{ ansistrano_git_repo }}"
-    dest: "{{ ansistrano_deploy_to }}/repo"
+    dest: "{{ ansistrano_deploy_to }}/{{ ansistrano_repo_dir }}"
     version: "{{ ansistrano_git_branch }}"
     accept_hostkey: true
     update: yes
@@ -69,6 +69,6 @@
            | sed "s#^$prefix/##"
            | rsync -a --files-from=- "./$prefix/" {{ ansistrano_release_path.stdout }}/
   args:
-    chdir: "{{ ansistrano_deploy_to }}/repo/"
+    chdir: "{{ ansistrano_deploy_to }}/{{ ansistrano_repo_dir }}/"
   environment:
     prefix: "{{ ansistrano_git_real_repo_tree }}"

--- a/tasks/update-code/hg.yml
+++ b/tasks/update-code/hg.yml
@@ -2,7 +2,7 @@
 - name: ANSISTRANO | HG | Update remote repository
   hg:
     repo: "{{ ansistrano_hg_repo }}"
-    dest: "{{ ansistrano_deploy_to }}/repo"
+    dest: "{{ ansistrano_deploy_to }}/{{ ansistrano_repo_dir }}"
     revision: "{{ ansistrano_hg_branch }}"
     force: yes
   register: ansistrano_hg_result
@@ -15,4 +15,4 @@
 - name: ANSISTRANO | HG | Sync repo to release path
   shell: "hg archive -r {{ ansistrano_hg_branch }} {{ ansistrano_release_path.stdout }}"
   args:
-    chdir: "{{ ansistrano_deploy_to }}/repo/"
+    chdir: "{{ ansistrano_deploy_to }}/{{ ansistrano_repo_dir }}/"

--- a/tasks/update-code/svn.yml
+++ b/tasks/update-code/svn.yml
@@ -2,7 +2,7 @@
 - name: ANSISTRANO | SVN | Update remote repository
   subversion:
     repo: "{{ ansistrano_svn_repo }}/{{ ansistrano_svn_branch }}"
-    dest: "{{ ansistrano_deploy_to }}/repo"
+    dest: "{{ ansistrano_deploy_to }}/{{ ansistrano_repo_dir }}"
     revision: "{{ ansistrano_svn_revision }}"
     username: "{{ ansistrano_svn_username }}"
     password: "{{ ansistrano_svn_password }}"
@@ -20,7 +20,7 @@
 
 - name: ANSISTRANO | SVN | Copy repo to release path
   subversion:
-    repo: "{{ ansistrano_deploy_to }}/repo"
+    repo: "{{ ansistrano_deploy_to }}/{{ ansistrano_repo_dir }}"
     dest: "{{ ansistrano_release_path.stdout }}"
     revision: "{{ ansistrano_svn_revision }}"
     username: "{{ ansistrano_svn_username }}"

--- a/test/setup.yml
+++ b/test/setup.yml
@@ -39,3 +39,4 @@
         - unzip
         - subversion
         - mercurial
+        - findutils


### PR DESCRIPTION
I have a site where the code is split into 2 repositories. When setting up Ansistrano to deploy in this scenario, I noticed that, when I deploy one repo, the directory "repo" gets clobbered when I deploy the second repo. Being able to name that directory resolves the name collision.