### PR TITLE
Exclude tests files from Ansible Galaxy

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+docs/ export-ignore
+example/ export-ignore
+test/ export-ignore
+TESTING.md export-ignore
+Vagrantfile export-ignore


### PR DESCRIPTION
Based on the trick from https://github.com/ansible/galaxy/issues/78,
I propose a `.gitattributes` file for excluding tests-related files from Ansible Galaxy.

It's not much but I had an issue with the symlink `test/roles/local-ansistrano`, I got caught in a loop with `rsync --copy-dirlinks` because of this relative symlink.