### PR TITLE
Fix regular expression mistake in Python 3.7

### DIFF
--- a/tasks/rsync-deploy.yml
+++ b/tasks/rsync-deploy.yml
@@ -34,7 +34,7 @@
   file:
     state: link
     path: "{{ ansistrano_deploy_to }}/{{ ansistrano_current_dir }}/{{ item }}"
-    src: "{{ item | regex_replace('[^\\/]*', '..') }}/shared/{{ item }}"
+    src: "{{ item | regex_replace('[^\\/]+', '..') }}/shared/{{ item }}"
   with_flattened:
     - "{{ ansistrano_shared_paths }}"
     - "{{ ansistrano_shared_files }}"


### PR DESCRIPTION
Python 3.7 subtly changed the behavior of re.sub() which leads to paths
like `..../....` where they should look like `../..`.

By matching only non-empty path segments, there is no second-adjacent
empty match that would be replaced.