### PR TITLE
Fix Ansible 2.8 bare variable deprecation warnings

### DIFF
--- a/tasks/setup.yml
+++ b/tasks/setup.yml
@@ -21,7 +21,7 @@
     state: directory
     path: "{{ ansistrano_shared_path }}/{{ item }}"
   with_items: "{{ ansistrano_shared_paths }}"
-  when: ansistrano_ensure_shared_paths_exist
+  when: ansistrano_ensure_shared_paths_exist|bool
 
 # Ensure basedir shared files exists
 - name: ANSISTRANO | Ensure basedir shared files exists
@@ -29,4 +29,4 @@
     state: directory
     path: "{{ ansistrano_shared_path }}/{{ item | dirname }}"
   with_items: "{{ ansistrano_shared_files }}"
-  when: ansistrano_ensure_basedirs_shared_files_exist
+  when: ansistrano_ensure_basedirs_shared_files_exist|bool


### PR DESCRIPTION
This includes the fix from #328, and fixes a few more. Example deprecation warnings we're seeing:

```
[DEPRECATION WARNING]: evaluating ansistrano_ensure_shared_paths_exist as a bare variable, this behaviour will go away and you might need to add |bool to the expression in the future. Also
see CONDITIONAL_BARE_VARS configuration toggle.. This feature will be removed in version 2.12. Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.
```
```
[DEPRECATION WARNING]: evaluating ansistrano_ensure_basedirs_shared_files_exist as a bare variable, this behaviour will go away and you might need to add |bool to the expression in the
future. Also see CONDITIONAL_BARE_VARS configuration toggle.. This feature will be removed in version 2.12. Deprecation warnings can be disabled by setting deprecation_warnings=False in
ansible.cfg.
```
```
[DEPRECATION WARNING]: evaluating ansistrano_allow_anonymous_stats as a bare variable, this behaviour will go away and you might need to add |bool to the expression in the future. Also see
CONDITIONAL_BARE_VARS configuration toggle.. This feature will be removed in version 2.12. Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.
```