### PR TITLE
Add ansistrano_keep_releases casting to int to avoid "Unexpected templating type error"

### DIFF
--- a/tasks/cleanup.yml
+++ b/tasks/cleanup.yml
@@ -2,4 +2,4 @@
 # Clean up releases
 - name: ANSISTRANO | Clean up releases
   shell: ls -1dt {{ ansistrano_releases_path }}/* | tail -n +{{ ansistrano_keep_releases | int + 1 }} | xargs rm -rf
-  when: ansistrano_keep_releases > 0
+  when: ansistrano_keep_releases | int > 0


### PR DESCRIPTION
I faced the following problem when I made a Python upgrade to 3.7.4:

```
fatal: [host]: FAILED! => {}

MSG:

The conditional check 'ansistrano_keep_releases > 0' failed. The error was: Unexpected templating type error occurred on ({% if ansistrano_keep_releases > 0 %} True {% else %} False {% endif %}): '>' not supported between instances of 'str' and 'int'

The error appears to have been in '/path/to/playbook/roles/ansistrano.deploy/tasks/cleanup.yml': line 3, column 3, but may
be elsewhere in the file depending on the exact syntax problem.

The offending line appears to be:

# Clean up releases
- name: ANSISTRANO | Clean up releases
  ^ here
```

The problem was in `when` statement:

`when: ansistrano_keep_releases > 0`

`ansistrano_keep_releases` is treated as a string, but there we have comparison int and string. This change solves the issue.