### PR TITLE
Add rsync_direct deployment strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ Is Ansistrano ready to be used? Here are some companies currently using it:
 * [HackSoft](https://hacksoft.io/)
 * [HackConf](https://hackconf.bg/en/)
 * [Hexanet](https://www.hexanet.fr)
+* [HiringThing](https://www.hiringthing.com/)
 * [Holaluz](https://www.holaluz.com)
 * [Hosting4devs](https://hosting4devs.com)
 * [Jolicode](http://jolicode.com/)
@@ -119,7 +120,7 @@ Requirements
 In order to deploy your apps with Ansistrano, you will need:
 
 * Ansible in your deployer machine
-* `rsync` on the target machine if you are using either the `rsync` or `git` deployment strategy or if you are using `ansistrano_current_via = rsync`
+* `rsync` on the target machine if you are using either the `rsync`, `rsync_direct`, or `git` deployment strategy or if you are using `ansistrano_current_via = rsync`
 
 Installation
 ------------
@@ -192,11 +193,16 @@ vars:
   # By default the shared paths directories and base directories for shared files are created automatically if not exists. But in some scenarios those paths could be symlinks to another directories in the filesystem, and the deployment process would fails. With these variables you can disable the involved tasks. If you have two or three shared paths, and don't need creation only for some of them, you always could disable the automatic creation and add a custom task in a hook.
   ansistrano_ensure_shared_paths_exist: yes
   ansistrano_ensure_basedirs_shared_files_exist: yes
-
-  ansistrano_deploy_via: "rsync" # Method used to deliver the code to the server. Options are copy, rsync, rsync_direct (direct rsync without needing to copy from ansistrano_shared_rsync_copy_path to ansistrano_release_path), git, svn, s3 or download. Copy, download and s3 have an optional step to unarchive the downloaded file which can be used by adding _unarchive. You can check all the options inside tasks/update-code folder!
+  
+  # Deployment strategy - method used to deliver code. Options are copy, download, git, rsync, rsync_direct, svn, or s3. 
+  ansistrano_deploy_via: "rsync" 
+  # Copy, download and s3 have an optional step to unarchive the downloaded file which can be used by adding _unarchive. 
+  # The rsync_direct strategy omits a file copy on the target offering a slight speed increase if you are deploying to shared hosts, are experiancing bad file-performance, or serve static assets from the same host you deploy your app to and rsync many files.
+  # You can check all the options inside tasks/update-code folder!
+  
   ansistrano_allow_anonymous_stats: yes
 
-  # Variables used in the rsync deployment strategy
+  # Variables used in the rsync/rsync_direct deployment strategy
   ansistrano_rsync_extra_params: "" # Extra parameters to use when deploying with rsync in a single string. Although Ansible allows an array this can cause problems if we try to add multiple --include args as it was reported in https://github.com/ansistrano/deploy/commit/e98942dc969d4e620313f00f003a7ea2eab67e86
   ansistrano_rsync_set_remote_user: yes # See [ansible synchronize module](http://docs.ansible.com/ansible/synchronize_module.html). Options are yes, no.
   ansistrano_rsync_path: "" # See [ansible synchronize module](http://docs.ansible.com/ansible/synchronize_module.html). By default is "sudo rsync", it can be overwriten with (example): "sudo -u user rsync".

--- a/README.md
+++ b/README.md
@@ -9,20 +9,27 @@ Ansistrano
 
 **ansistrano.deploy** and **ansistrano.rollback** are Ansible roles to easily manage the deployment process for scripting applications such as PHP, Python and Ruby. It's an Ansible port for Capistrano.
 
-- [Requirements](#requirements)
-- [Installation](#installation)
-- [Update](#update)
-- [Features](#features)
-- [Main workflow](#main-workflow)
-- [Role Variables](#role-variables)
-- [Deploying](#deploying)
-- [Rolling back](#rolling-back)
-- [Multistage environment (devel, preprod, prod, etc.)](#multistage-environment-devel-preprod-prod-etc)
-- [Hooks: Custom tasks](#hooks-custom-tasks)
-- [Variables in custom tasks](#variables-in-custom-tasks)
-- [Pruning old releases](#pruning-old-releases)
-- [Example Playbook](#example-playbook)
-- [Sample projects](#sample-projects)
+- [Ansistrano](#ansistrano)
+  - [History](#history)
+  - [Project name](#project-name)
+  - [Ansistrano anonymous usage stats](#ansistrano-anonymous-usage-stats)
+  - [Who is using Ansistrano?](#who-is-using-ansistrano)
+  - [Requirements](#requirements)
+  - [Installation](#installation)
+  - [Update](#update)
+  - [Features](#features)
+  - [Main workflow](#main-workflow)
+  - [Role Variables](#role-variables)
+  - [Deploying](#deploying)
+  - [Rolling back](#rolling-back)
+  - [Hooks: Custom tasks](#hooks-custom-tasks)
+  - [Variables in custom tasks](#variables-in-custom-tasks)
+  - [Pruning old releases](#pruning-old-releases)
+  - [Example Playbook](#example-playbook)
+  - [Sample projects](#sample-projects)
+  - [They're talking about us](#theyre-talking-about-us)
+  - [License](#license)
+  - [Other resources](#other-resources)
 
 History
 -------
@@ -186,7 +193,7 @@ vars:
   ansistrano_ensure_shared_paths_exist: yes
   ansistrano_ensure_basedirs_shared_files_exist: yes
 
-  ansistrano_deploy_via: "rsync" # Method used to deliver the code to the server. Options are copy, rsync, git, svn, s3 or download. Copy, download and s3 have an optional step to unarchive the downloaded file which can be used by adding _unarchive. You can check all the options inside tasks/update-code folder!
+  ansistrano_deploy_via: "rsync" # Method used to deliver the code to the server. Options are copy, rsync, rsync_direct (direct rsync without needing to copy from ansistrano_shared_rsync_copy_path to ansistrano_release_path), git, svn, s3 or download. Copy, download and s3 have an optional step to unarchive the downloaded file which can be used by adding _unarchive. You can check all the options inside tasks/update-code folder!
   ansistrano_allow_anonymous_stats: yes
 
   # Variables used in the rsync deployment strategy

--- a/tasks/update-code/rsync_direct.yml
+++ b/tasks/update-code/rsync_direct.yml
@@ -1,12 +1,8 @@
 ---
-- name: ANSISTRANO | RSYNC | Get Release path (in rsync_direct case)
-  command: echo "{{ ansistrano_release_path.stdout }}"
-  register: ansistrano_release_rsync_copy_path
-
-- name: ANSISTRANO | RSYNC | Rsync application files to remote release path
+- name: ANSISTRANO | RSYNC DIRECT | Rsync application files directly to remote release path
   synchronize:
     src: "{{ ansistrano_deploy_from }}"
-    dest: "{{ ansistrano_release_rsync_copy_path.stdout }}"
+    dest: "{{ ansistrano_release_path.stdout }}"
     set_remote_user: "{{ ansistrano_rsync_set_remote_user }}"
     recursive: yes
     delete: yes

--- a/tasks/update-code/rsync_direct.yml
+++ b/tasks/update-code/rsync_direct.yml
@@ -1,0 +1,17 @@
+---
+- name: ANSISTRANO | RSYNC | Get Release path (in rsync_direct case)
+  command: echo "{{ ansistrano_release_path.stdout }}"
+  register: ansistrano_release_rsync_copy_path
+
+- name: ANSISTRANO | RSYNC | Rsync application files to remote release path
+  synchronize:
+    src: "{{ ansistrano_deploy_from }}"
+    dest: "{{ ansistrano_release_rsync_copy_path.stdout }}"
+    set_remote_user: "{{ ansistrano_rsync_set_remote_user }}"
+    recursive: yes
+    delete: yes
+    archive: yes
+    compress: yes
+    use_ssh_args: "{{ ansistrano_rsync_use_ssh_args | default(omit) }}"
+    rsync_opts: "{{ ansistrano_rsync_extra_params | default(omit) }}"
+    rsync_path: "{{ ansistrano_rsync_path | default(omit) }}"

--- a/test/main.yml
+++ b/test/main.yml
@@ -1,6 +1,7 @@
 ---
 - import_playbook: setup.yml
 - import_playbook: rsync-test.yml
+- import_playbook: rsync_direct-test.yml
 - import_playbook: git-test.yml
 - import_playbook: download-test.yml
 - import_playbook: svn-test.yml

--- a/test/rsync_direct-test.yml
+++ b/test/rsync_direct-test.yml
@@ -1,0 +1,131 @@
+---
+# Tests for rsync_direct strategy
+- name: Given no previous deploy
+  hosts: all
+  vars:
+    ansistrano_deploy_to: "/tmp/my-app.com"
+  tasks:
+    - name: Assert ansistrano_deploy_to path does not exist
+      stat:
+        path: "{{ ansistrano_deploy_to }}"
+      register: st
+    - debug:
+        msg: "Path does not exist and is a directory"
+      when: st.stat.exists is defined and not st.stat.exists
+
+- name: When deploying
+  hosts: all
+  vars:
+    ansistrano_deploy_via: "rsync_direct"
+    ansistrano_deploy_to: "/tmp/my-app.com"
+    ansistrano_after_setup_tasks_file: "{{ playbook_dir }}/tasks/create-shared-paths.yml"
+    ansistrano_after_update_code_tasks_file: "{{ playbook_dir }}/tasks/create-internal-paths.yml"
+    ansistrano_shared_paths:
+      - blah
+      - foo/bar
+      - xxx/yyy/zzz
+    ansistrano_shared_files:
+      - test.txt
+      - files/test.txt
+  roles:
+    - { role: local-ansistrano }
+
+- name: Then a successful deploy with rsync_direct should be done
+  hosts: all
+  vars:
+    ansistrano_deploy_to: "/tmp/my-app.com"
+  tasks:
+    - name: Assert ansistrano_deploy_to path does exist
+      stat:
+        path: "{{ ansistrano_deploy_to }}"
+      register: st
+    - debug:
+        msg: "Path exists and is a directory"
+      when: st.stat.exists is defined and st.stat.exists
+    - name: Assert ansistrano_deploy_to/current path does exist
+      stat:
+        path: "{{ ansistrano_deploy_to }}/current"
+      register: st
+    - fail:
+        msg: "Path is not a symlink"
+      when: st.stat.exists is defined and st.stat.exists and st.stat.islnk == False
+    - debug:
+        msg: "Path exists and is a symlink"
+      when: st.stat.exists is defined and st.stat.exists and st.stat.islnk
+
+- name: And I should be able to do a second deploy
+  hosts: all
+  vars:
+    ansistrano_deploy_via: "rsync_direct"
+    ansistrano_deploy_to: "/tmp/my-app.com"
+    ansistrano_after_setup_tasks_file: "{{ playbook_dir }}/tasks/create-shared-paths.yml"
+    ansistrano_after_update_code_tasks_file: "{{ playbook_dir }}/tasks/create-internal-paths.yml"
+    ansistrano_shared_paths:
+      - blah
+      - foo/bar
+      - xxx/yyy/zzz
+    ansistrano_shared_files:
+      - test.txt
+      - files/test.txt
+  roles:
+    - { role: local-ansistrano }
+
+# Tests for rsync_direct strategy with "current" via rsync (instead of the default symlink)
+- name: When deploying with rsync current strategy
+  hosts: all
+  vars:
+    ansistrano_deploy_via: "rsync_direct"
+    ansistrano_deploy_to: "/tmp/my-app.com"
+    ansistrano_after_setup_tasks_file: "{{ playbook_dir }}/tasks/create-shared-paths.yml"
+    ansistrano_after_update_code_tasks_file: "{{ playbook_dir }}/tasks/create-internal-paths.yml"
+    ansistrano_current_via: "rsync"
+    ansistrano_shared_paths:
+      - blah
+      - foo/bar
+      - xxx/yyy/zzz
+    ansistrano_shared_files:
+      - test.txt
+      - files/test.txt
+  roles:
+    - { role: local-ansistrano }
+
+- name: Then a successful deploy with rsync should be done
+  hosts: all
+  vars:
+    ansistrano_deploy_to: "/tmp/my-app.com"
+  tasks:
+    - name: Assert ansistrano_deploy_to path does exist
+      stat:
+        path: "{{ ansistrano_deploy_to }}"
+      register: st
+    - debug:
+        msg: "Path exists and is a directory"
+      when: st.stat.exists is defined and st.stat.exists
+    - name: Assert ansistrano_deploy_to/current path does exist
+      stat:
+        path: "{{ ansistrano_deploy_to }}/current"
+      register: st
+    - fail:
+        msg: "Path is not a directory"
+      when: st.stat.exists is defined and st.stat.exists and st.stat.isdir == False
+    - debug:
+        msg: "Path exists and is a directory"
+      when: st.stat.exists is defined and st.stat.exists and st.stat.isdir
+
+- name: And I should be able to do a second deploy
+  hosts: all
+  vars:
+    ansistrano_deploy_via: "rsync_direct"
+    ansistrano_deploy_to: "/tmp/my-app.com"
+    ansistrano_after_setup_tasks_file: "{{ playbook_dir }}/tasks/create-shared-paths.yml"
+    ansistrano_after_update_code_tasks_file: "{{ playbook_dir }}/tasks/create-internal-paths.yml"
+    ansistrano_current_via: "rsync"
+    ansistrano_shared_paths:
+      - blah
+      - foo/bar
+      - xxx/yyy/zzz
+    ansistrano_shared_files:
+      - test.txt
+      - files/test.txt
+  roles:
+    - { role: local-ansistrano }


### PR DESCRIPTION
Adds a `rsync_direct` deployment strategy which is slightly faster than the default `rsync` because it skips the copy step from the `ansistrano_shared_rsync_copy_path` to `ansistrano_release_path` for #243
