### PR TITLE
feat: add the possibility to exclude files from an archive when extra…

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -84,3 +84,6 @@ ansistrano_allow_anonymous_stats: yes
 
 ansistrano_unarchive_owner: "default"
 ansistrano_unarchive_group: "default"
+## Exclude some files or directory
+## * is allowed (ex: *.pdf, *.docx)
+ansistrano_unarchive_exclude: []

--- a/tasks/update-code/unarchive.yml
+++ b/tasks/update-code/unarchive.yml
@@ -4,6 +4,7 @@
     copy: no
     src: "{{ ansistrano_archived_file }}"
     dest: "{{ ansistrano_release_path.stdout }}"
+    exclude: "{{ ansistrano_unarchive_exclude }}"
   when: ansistrano_unarchive_owner == "default" and ansistrano_unarchive_group == "default"
 
 - name: ANSISTRANO | Unarchive | Unarchive source
@@ -20,6 +21,7 @@
     dest: "{{ ansistrano_release_path.stdout }}"
     owner: "{{ ansistrano_unarchive_owner }}"
     group: "{{ ansistrano_unarchive_group }}"
+    exclude: "{{ ansistrano_unarchive_exclude }}"
   when: >
     ansistrano_unarchive_owner != "default" and
     ansistrano_unarchive_group != "default"


### PR DESCRIPTION
…cting it (ansible module unarchive - exclude parameter)

I need to exclude some files from an archive when extracting it.

I suggest to use the module's parameter exclude.

It can be use as follow 

`ansistrano_unarchive_exclude: ['*.pdf','*.xlsx','*.doc']`
