### PR TITLE
Added the option to change the executable path for git

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,7 @@ vars:
   ansistrano_git_refspec: ADDITIONAL_GIT_REFSPEC # Additional refspec to be used by the 'git' module. Uses the same syntax as the 'git fetch' command.
   ansistrano_git_ssh_opts: "-o StrictHostKeyChecking=no" # Additional ssh options to be used in Git
   ansistrano_git_depth: 1 # Additional history truncated to the specified number or revisions
+  ansistrano_git_executable: "" # Path to git executable to use. If not supplied, the normal mechanism for resolving binary paths will be used.
 
   # Variables used in the SVN deployment strategy
   # Please note there was a bug in the subversion module in Ansible 1.8.x series (https://github.com/ansible/ansible-modules-core/issues/370) so it is only supported from Ansible 1.9

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -49,6 +49,7 @@ ansistrano_git_branch: master
 ansistrano_git_repo_tree: ""
 ansistrano_git_identity_key_path: ""
 ansistrano_git_identity_key_remote_path: ""
+ansistrano_git_executable: ""
 
 ## SVN pull strategy
 ansistrano_svn_repo: "https://svn.company.com/project"

--- a/tasks/update-code/git.yml
+++ b/tasks/update-code/git.yml
@@ -25,6 +25,7 @@
     ssh_opts: "{{ ansistrano_git_ssh_opts | default(omit) }}"
     refspec: "{{ ansistrano_git_refspec | default(omit) }}"
     depth: "{{ ansistrano_git_depth | default(omit) }}"
+    executable: "{{ ansistrano_git_executable | default(omit) }}"
   register: ansistrano_git_result_update
   when: not ansistrano_git_identity_key_path|trim and not ansistrano_git_identity_key_remote_path|trim
 
@@ -40,6 +41,7 @@
     refspec: "{{ ansistrano_git_refspec | default(omit) }}"
     depth: "{{ ansistrano_git_depth | default(omit) }}"
     key_file: "{{ ansistrano_deploy_to }}/git_identity_key"
+    executable: "{{ ansistrano_git_executable | default(omit) }}"
   register: ansistrano_git_result_update_ssh
   when: ansistrano_git_identity_key_path|trim or ansistrano_git_identity_key_remote_path|trim
 


### PR DESCRIPTION
My deployment failed on a managed server, where git was not installed in the usual binary path. 
So I added the possibility to change the executable path for git. 