### PR TITLE
Replaced `with_flattened` with `with_items`

### DIFF
--- a/tasks/rsync-deploy.yml
+++ b/tasks/rsync-deploy.yml
@@ -26,9 +26,9 @@
   file:
     state: absent
     path: "{{ ansistrano_deploy_to }}/{{ ansistrano_current_dir }}/{{ item }}"
-  with_flattened:
-    - "{{ ansistrano_shared_paths }}"
-    - "{{ ansistrano_shared_files }}"
+  with_items:
+    - "{{ ansistrano_shared_paths|flatten }}"
+    - "{{ ansistrano_shared_files|flatten }}"
 
 # Symlinks shared paths
 - name: ANSISTRANO | Create softlinks for shared paths
@@ -36,6 +36,6 @@
     state: link
     path: "{{ ansistrano_deploy_to }}/{{ ansistrano_current_dir }}/{{ item }}"
     src: "{{ item | regex_replace('[^\\/]+', '..') }}/shared/{{ item }}"
-  with_flattened:
-    - "{{ ansistrano_shared_paths }}"
-    - "{{ ansistrano_shared_files }}"
+  with_items:
+    - "{{ ansistrano_shared_paths|flatten }}"
+    - "{{ ansistrano_shared_files|flatten }}"

--- a/tasks/symlink-shared.yml
+++ b/tasks/symlink-shared.yml
@@ -6,9 +6,9 @@
   file:
     state: absent
     path: "{{ ansistrano_release_path.stdout }}/{{ item }}"
-  with_flattened:
-    - "{{ ansistrano_shared_paths }}"
-    - "{{ ansistrano_shared_files }}"
+  with_items:
+    - "{{ ansistrano_shared_paths|flatten }}"
+    - "{{ ansistrano_shared_files|flatten }}"
 
 # Symlinks shared paths and files
 - name: ANSISTRANO | Create softlinks for shared paths and files
@@ -16,9 +16,9 @@
     state: link
     path: "{{ ansistrano_release_path.stdout }}/{{ item }}"
     src: "{{ item | regex_replace('[^\\/]+', '..') }}/../shared/{{ item }}"
-  with_flattened:
-    - "{{ ansistrano_shared_paths }}"
-    - "{{ ansistrano_shared_files }}"
+  with_items:
+    - "{{ ansistrano_shared_paths|flatten }}"
+    - "{{ ansistrano_shared_files|flatten }}"
 
 # Remove previous .rsync-filter file (rsync current deployment)
 - name: ANSISTRANO | Ensure .rsync-filter is absent
@@ -33,7 +33,7 @@
     dest: "{{ ansistrano_release_path.stdout }}/.rsync-filter"
     line: "- /{{ item }}"
     create: yes
-  with_flattened:
-    - "{{ ansistrano_shared_paths }}"
-    - "{{ ansistrano_shared_files }}"
+  with_items:
+    - "{{ ansistrano_shared_paths|flatten }}"
+    - "{{ ansistrano_shared_files|flatten }}"
   when: ansistrano_current_via == "rsync"


### PR DESCRIPTION
This Pull request solves the following issue in ansible version 2.10.0

```
 FAILED! => {"reason": "'with_flattened' is not a valid attribute for a Task...
```

`with_flattened` was replaced by `with_items` combined with the filter `flatten`.

It is documented by ansible itself https://docs.ansible.com/ansible/latest/user_guide/playbooks_loops.html#with-flattened
Ansible recommends to use `loop` instead of `with_flattened`, but that didn`t worked in my project.