### PR TITLE
Avoid Apt deprecation warning

### DIFF
--- a/test/setup.yml
+++ b/test/setup.yml
@@ -16,16 +16,15 @@
     - name: Install Required Packages For Debian
       when: ansible_os_family == 'Debian'
       apt:
-        name: "{{ item }}"
+        name:
+          - rsync
+          - tar
+          - ssh
+          - git
+          - unzip
+          - subversion
+          - mercurial
         state: present
-      with_items:
-        - rsync
-        - tar
-        - ssh
-        - git
-        - unzip
-        - subversion
-        - mercurial
 
     - name: Install Required Packages For Redhat
       when: ansible_os_family == 'RedHat'


### PR DESCRIPTION
From logs:
> [DEPRECATION WARNING]: Invoking "apt" only once while using a loop via 
> squash_actions is deprecated. Instead of using a loop to supply multiple items 
> and specifying `name: "{{ item }}"`, please use `name: ['rsync', 'tar', 'ssh', 
> 'git', 'unzip', 'subversion', 'mercurial']` and remove the loop. This feature 
> will be removed in version 2.11. Deprecation warnings can be disabled by 
> setting deprecation_warnings=False in ansible.cfg.