### PR TITLE
Avoid Yum deprecation warning

### DIFF
--- a/test/setup.yml
+++ b/test/setup.yml
@@ -30,14 +30,13 @@
     - name: Install Required Packages For Redhat
       when: ansible_os_family == 'RedHat'
       yum:
-        name: "{{ item }}"
+        name:
+          - rsync
+          - tar
+          - openssh-clients
+          - git
+          - unzip
+          - subversion
+          - mercurial
+          - findutils
         state: present
-      with_items:
-        - rsync
-        - tar
-        - openssh-clients
-        - git
-        - unzip
-        - subversion
-        - mercurial
-        - findutils


### PR DESCRIPTION
From logs:
> [DEPRECATION WARNING]: Invoking "yum" only once while using a loop via 
> squash_actions is deprecated. Instead of using a loop to supply multiple items 
> and specifying `name: "{{ item }}"`, please use `name: ['rsync', 'tar', 
> 'openssh-clients', 'git', 'unzip', 'subversion', 'mercurial', 'findutils']` and
>  remove the loop. This feature will be removed in version 2.11. Deprecation 
> warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.