### PR TITLE
Add run_once on funding tasks

### DIFF
--- a/tasks/funding.yml
+++ b/tasks/funding.yml
@@ -2,7 +2,9 @@
 - name: Thanks to all our generous sponsors!
   debug:
     msg: "Ansistrano is funded by: Rigor Guild, Holaluz"
+  run_once: true
 
 - name: Please consider sponsoring Ansistrano
   debug:
     msg: If Ansistrano is saving money for your company, please visit https://github.com/sponsors/ansistrano and consider a small donation!
+  run_once: true


### PR DESCRIPTION
Hi. When the funding.yml tasks are executed on a large inventory, they are literally spamming the console output with the funding info for every host. It makes scrolling up to see the deployment console output somewhat difficult; It can even hide the beginning of the output on some terminals limiting the number of lines you can scroll up in history.

This PR adds `run_once: true` to the funding.yml tasks, so that sponsors are only displayed once (and not 2 times 200 if I have an inventory of 200 hosts).