### PR TITLE
Add region in "Get object from Ceph RGW" task

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ vars:
   ansistrano_s3_bucket: s3bucket
   ansistrano_s3_object: s3object.tgz # Add the _unarchive suffix to the ansistrano_deploy_via if your object is a package (ie: s3_unarchive)
   ansistrano_s3_region: eu-west-1
-  ansistrano_s3_rgw: false # must be Ansible >= 2.2. use Ceph RGW (when set true, ignore ansistrano_s3_region)
+  ansistrano_s3_rgw: false # must be Ansible >= 2.2. use Ceph RGW for S3 compatible cloud providers
   ansistrano_s3_url: http://rgw.example.com # when use Ceph RGW, set url
   # Optional variables, omitted by default
   ansistrano_s3_aws_access_key: YOUR_AWS_ACCESS_KEY

--- a/tasks/update-code/s3.yml
+++ b/tasks/update-code/s3.yml
@@ -27,5 +27,6 @@
     mode: get
     aws_access_key: "{{ ansistrano_s3_aws_access_key | default(omit) }}"
     aws_secret_key: "{{ ansistrano_s3_aws_secret_key | default(omit) }}"
+    region: "{{ ansistrano_s3_region | default(omit) }}"
     ignore_nonexistent_bucket: "{{ ansistrano_s3_ignore_nonexistent_bucket | default(omit) }}"
   when: ansistrano_s3_rgw


### PR DESCRIPTION
Some cloud providers like OpenStack Swift from [OVH]( https://www.ovhcloud.com/en-gb/public-cloud/object-storage/) in EC2 mode need this region parameter to work.

Here is an example of how we're using this small change in our stack :
```yaml
ansistrano_deploy_via: s3_unarchive
ansistrano_s3_bucket: "some-bucket"
ansistrano_s3_object: "some-object.tar.gz"
ansistrano_s3_rgw: true
ansistrano_s3_aws_access_key: "{{ vaulted_access_key }}"
ansistrano_s3_aws_secret_key: "{{ vaulted_secret_key }}"
ansistrano_s3_url: "https://s3.gra.cloud.ovh.net"
ansistrano_s3_region: gra
```