### PR TITLE
Fix ansistrano.deploy issue 357

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,7 @@ vars:
   ansistrano_git_repo_tree: "" # If specified the subtree of the repository to deploy
   ansistrano_git_identity_key_path: "" # If specified this file is copied over and used as the identity key for the git commands, path is relative to the playbook in which it is used
   ansistrano_git_identity_key_remote_path: "" # If specified this file on the remote server is used as the identity key for the git commands, remote path is absolute
+  ansistrano_git_identity_key_shred: true # Shred identity key by default but can be overloaded to false if you encounter the following issue (https://github.com/ansistrano/deploy/issues/357)
   # Optional variables, omitted by default
   ansistrano_git_refspec: ADDITIONAL_GIT_REFSPEC # Additional refspec to be used by the 'git' module. Uses the same syntax as the 'git fetch' command.
   ansistrano_git_ssh_opts: "-o StrictHostKeyChecking=no" # Additional ssh options to be used in Git

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -49,6 +49,7 @@ ansistrano_git_branch: master
 ansistrano_git_repo_tree: ""
 ansistrano_git_identity_key_path: ""
 ansistrano_git_identity_key_remote_path: ""
+ansistrano_git_identity_key_shred: true
 
 ## SVN pull strategy
 ansistrano_svn_repo: "https://svn.company.com/project"

--- a/tasks/update-code/git.yml
+++ b/tasks/update-code/git.yml
@@ -50,7 +50,7 @@
 
 - name: ANSISTRANO | GIT | Shred GIT deployment key
   command: shred -f "{{ ansistrano_deploy_to }}/git_identity_key"
-  when: ansistrano_git_identity_key_path|trim or ansistrano_git_identity_key_remote_path|trim
+  when: (ansistrano_git_identity_key_path|trim or ansistrano_git_identity_key_remote_path|trim) and ansistrano_git_identity_key_shred|bool == true
 
 - name: ANSISTRANO | GIT | Set git_real_repo_tree
   set_fact:


### PR DESCRIPTION
Give the ability to disable the shred command when we use the Git method and if we encounter the issue 357 (https://github.com/ansistrano/deploy/issues/357).
- A variable is added in the "defaults/main.yml" file and is set to true by default so it won't change the default behavior.
- The condition of the shred task in the "tasks/update-code/git.yml" file has been updated.
- The "README.md" file has been updated.