### PR TITLE
Add variable `ansistrano_repo_path` and calculate relative paths for symlinks using `relpath`

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -16,6 +16,7 @@ ansistrano_shared_path: "{{ ansistrano_deploy_to }}/shared"
 
 # Softlink name for the current release
 ansistrano_current_dir: "current"
+ansistrano_current_path: "{{ ansistrano_deploy_to }}/{{ ansistrano_current_dir }}"
 
 # Current directory deployment strategy
 ansistrano_current_via: "symlink"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -42,6 +42,7 @@ ansistrano_keep_releases: 0
 
 # Directory name for the checked out repository
 ansistrano_repo_dir: "repo"
+ansistrano_repo_path: "{{ ansistrano_deploy_to }}/{{ ansistrano_repo_dir }}"
 
 ## GIT pull strategy
 ansistrano_git_repo: git@github.com:USERNAME/REPO.git

--- a/tasks/rsync-deploy.yml
+++ b/tasks/rsync-deploy.yml
@@ -3,29 +3,29 @@
 # Migration check from symlink deployment
 - name: ANSISTRANO | Get current folder
   stat:
-    path: "{{ ansistrano_deploy_to }}/{{ ansistrano_current_dir }}"
+    path: "{{ ansistrano_current_path }}"
   register: stat_current_dir
 
 - name: ANSISTRANO | Remove current folder if it's a symlink
   file:
     state: absent
-    path: "{{ ansistrano_deploy_to }}/{{ ansistrano_current_dir }}"
+    path: "{{ ansistrano_current_path }}"
   when: stat_current_dir.stat.islnk is defined and stat_current_dir.stat.islnk
 
 # Perform rsync deployment
 - name: ANSISTRANO | Ensure current folder is a directory
   file:
     state: directory
-    path: "{{ ansistrano_deploy_to }}/{{ ansistrano_current_dir }}"
+    path: "{{ ansistrano_current_path }}"
 
 - name: ANSISTRANO | Sync release to new current path
-  command: rsync -a -F --no-times --delete-after "{{ ansistrano_release_path.stdout }}/" "{{ ansistrano_deploy_to }}/{{ ansistrano_current_dir }}/"
+  command: rsync -a -F --no-times --delete-after "{{ ansistrano_release_path.stdout }}/" "{{ ansistrano_current_path }}/"
 
 # Ensure symlinks target paths is absent
 - name: ANSISTRANO | Ensure shared paths targets are absent
   file:
     state: absent
-    path: "{{ ansistrano_deploy_to }}/{{ ansistrano_current_dir }}/{{ item }}"
+    path: "{{ ansistrano_current_path }}/{{ item }}"
   with_flattened:
     - "{{ ansistrano_shared_paths }}"
     - "{{ ansistrano_shared_files }}"
@@ -34,8 +34,8 @@
 - name: ANSISTRANO | Create softlinks for shared paths
   file:
     state: link
-    path: "{{ ansistrano_deploy_to }}/{{ ansistrano_current_dir }}/{{ item }}"
-    src: "{{ (ansistrano_shared_path ~ '/' ~ item) | relpath((ansistrano_deploy_to ~ '/' ~ ansistrano_current_dir ~ '/' ~ item) | dirname) }}"
+    path: "{{ ansistrano_current_path }}/{{ item }}"
+    src: "{{ (ansistrano_shared_path ~ '/' ~ item) | relpath((ansistrano_current_path ~ '/' ~ item) | dirname) }}"
   with_flattened:
     - "{{ ansistrano_shared_paths }}"
     - "{{ ansistrano_shared_files }}"

--- a/tasks/rsync-deploy.yml
+++ b/tasks/rsync-deploy.yml
@@ -35,7 +35,7 @@
   file:
     state: link
     path: "{{ ansistrano_deploy_to }}/{{ ansistrano_current_dir }}/{{ item }}"
-    src: "{{ item | regex_replace('[^\\/]+', '..') }}/shared/{{ item }}"
+    src: "{{ (ansistrano_shared_path ~ '/' ~ item) | relpath((ansistrano_deploy_to ~ '/' ~ ansistrano_current_dir ~ '/' ~ item) | dirname) }}"
   with_flattened:
     - "{{ ansistrano_shared_paths }}"
     - "{{ ansistrano_shared_files }}"

--- a/tasks/symlink-shared.yml
+++ b/tasks/symlink-shared.yml
@@ -13,7 +13,7 @@
   file:
     state: link
     path: "{{ ansistrano_release_path.stdout }}/{{ item }}"
-    src: "{{ item | regex_replace('[^\\/]+', '..') }}/../shared/{{ item }}"
+    src: "{{ (ansistrano_shared_path ~ '/' ~ item) | relpath((ansistrano_release_path.stdout ~ '/' ~ item) | dirname) }}"
   loop: "{{ (ansistrano_shared_paths | flatten ) + (ansistrano_shared_files | flatten) }}"
 
 # Remove previous .rsync-filter file (rsync current deployment)

--- a/tasks/symlink.yml
+++ b/tasks/symlink.yml
@@ -3,18 +3,18 @@
 # Migration check from rsync deployment
 - name: ANSISTRANO | Get current folder
   stat:
-    path: "{{ ansistrano_deploy_to }}/{{ ansistrano_current_dir }}"
+    path: "{{ ansistrano_current_path }}"
   register: stat_current_dir
 
 - name: ANSISTRANO | Remove current folder if it's a directory
   file:
     state: absent
-    path: "{{ ansistrano_deploy_to }}/{{ ansistrano_current_dir }}"
+    path: "{{ ansistrano_current_path }}"
   when: stat_current_dir.stat.isdir is defined and stat_current_dir.stat.isdir
 
 # Performs symlink exchange
 - name: ANSISTRANO | Change softlink to new release
   file:
     state: link
-    path: "{{ ansistrano_deploy_to }}/{{ ansistrano_current_dir }}"
-    src: "{{ (ansistrano_deploy_to ~ '/' ~ ansistrano_version_dir ~ '/' ~ ansistrano_release_version) | relpath((ansistrano_deploy_to ~ '/' ~ ansistrano_current_dir) | dirname) }}"
+    path: "{{ ansistrano_current_path }}"
+    src: "{{ (ansistrano_deploy_to ~ '/' ~ ansistrano_version_dir ~ '/' ~ ansistrano_release_version) | relpath(ansistrano_current_path | dirname) }}"

--- a/tasks/symlink.yml
+++ b/tasks/symlink.yml
@@ -17,4 +17,4 @@
   file:
     state: link
     path: "{{ ansistrano_deploy_to }}/{{ ansistrano_current_dir }}"
-    src: "./{{ ansistrano_version_dir }}/{{ ansistrano_release_version }}"
+    src: "{{ (ansistrano_deploy_to ~ '/' ~ ansistrano_version_dir ~ '/' ~ ansistrano_release_version) | relpath((ansistrano_deploy_to ~ '/' ~ ansistrano_current_dir) | dirname) }}"

--- a/tasks/symlink.yml
+++ b/tasks/symlink.yml
@@ -17,4 +17,4 @@
   file:
     state: link
     path: "{{ ansistrano_current_path }}"
-    src: "{{ (ansistrano_deploy_to ~ '/' ~ ansistrano_version_dir ~ '/' ~ ansistrano_release_version) | relpath(ansistrano_current_path | dirname) }}"
+    src: "{{ (ansistrano_releases_path ~ '/' ~ ansistrano_release_version) | relpath(ansistrano_current_path | dirname) }}"

--- a/tasks/update-code/git.yml
+++ b/tasks/update-code/git.yml
@@ -17,7 +17,7 @@
 - name: ANSISTRANO | GIT | Update remote repository
   git:
     repo: "{{ ansistrano_git_repo }}"
-    dest: "{{ ansistrano_deploy_to }}/{{ ansistrano_repo_dir }}"
+    dest: "{{ ansistrano_repo_path }}"
     version: "{{ ansistrano_git_branch }}"
     accept_hostkey: true
     update: yes
@@ -32,7 +32,7 @@
 - name: ANSISTRANO | GIT | Update remote repository using SSH key
   git:
     repo: "{{ ansistrano_git_repo }}"
-    dest: "{{ ansistrano_deploy_to }}/{{ ansistrano_repo_dir }}"
+    dest: "{{ ansistrano_repo_path }}"
     version: "{{ ansistrano_git_branch }}"
     accept_hostkey: true
     update: yes
@@ -71,6 +71,6 @@
            | sed "s#^$prefix/##"
            | rsync -a --files-from=- "./$prefix/" {{ ansistrano_release_path.stdout }}/
   args:
-    chdir: "{{ ansistrano_deploy_to }}/{{ ansistrano_repo_dir }}/"
+    chdir: "{{ ansistrano_repo_path }}/"
   environment:
     prefix: "{{ ansistrano_git_real_repo_tree }}"

--- a/tasks/update-code/hg.yml
+++ b/tasks/update-code/hg.yml
@@ -2,7 +2,7 @@
 - name: ANSISTRANO | HG | Update remote repository
   hg:
     repo: "{{ ansistrano_hg_repo }}"
-    dest: "{{ ansistrano_deploy_to }}/{{ ansistrano_repo_dir }}"
+    dest: "{{ ansistrano_repo_path }}"
     revision: "{{ ansistrano_hg_branch }}"
     force: yes
   register: ansistrano_hg_result
@@ -15,4 +15,4 @@
 - name: ANSISTRANO | HG | Sync repo to release path
   command: "hg archive -r {{ ansistrano_hg_branch }} {{ ansistrano_release_path.stdout }}"
   args:
-    chdir: "{{ ansistrano_deploy_to }}/{{ ansistrano_repo_dir }}/"
+    chdir: "{{ ansistrano_repo_path }}/"

--- a/tasks/update-code/svn.yml
+++ b/tasks/update-code/svn.yml
@@ -2,7 +2,7 @@
 - name: ANSISTRANO | SVN | Update remote repository
   subversion:
     repo: "{{ ansistrano_svn_repo }}/{{ ansistrano_svn_branch }}"
-    dest: "{{ ansistrano_deploy_to }}/{{ ansistrano_repo_dir }}"
+    dest: "{{ ansistrano_repo_path }}"
     revision: "{{ ansistrano_svn_revision }}"
     username: "{{ ansistrano_svn_username }}"
     password: "{{ ansistrano_svn_password }}"
@@ -20,7 +20,7 @@
 
 - name: ANSISTRANO | SVN | Copy repo to release path
   subversion:
-    repo: "{{ ansistrano_deploy_to }}/{{ ansistrano_repo_dir }}"
+    repo: "{{ ansistrano_repo_path }}"
     dest: "{{ ansistrano_release_path.stdout }}"
     revision: "{{ ansistrano_svn_revision }}"
     username: "{{ ansistrano_svn_username }}"


### PR DESCRIPTION
Introduce new variable `ansistrano_repo_path` that can be used to specify an absolute repo path instead of `ansistrano_repo_dir`.
Defaults to `"{{ ansistrano_deploy_to }}/{{ ansistrano_repo_dir }}"`, because it was only ever used that way.

Use `relpath` and `dirname` to determine the relative link targets instead of regex. Fixes #238.

The `relpath` fix also allows for configurations like this:

```yml
ansistrano_deploy_to: "/var/www/my-app.com_ansistrano"
ansistrano_current_dir: "../my-app.com"
```

Which results in 
```
-- /var/www/
|-- my-app.com -> my-app.com_ansistrano/releases/20100509145325
|-- my-app.com_ansistrano
    |-- releases
    |   |-- 20100509145325
    |-- shared
```

(Make sure that `ansistrano_deploy_to` and `ansistrano_current_dir` don't point to the same location)

The `relpath` change probably also needs to be applied to the `rollback` role.

Please make sure to double and triple check my changes, as this is my first time using ansistrano and I'm not very experienced with ansible, either.