### PR TITLE
Set ansistrano_git_real_repo_tree to match only 1 directory

### DIFF
--- a/tasks/update-code/git.yml
+++ b/tasks/update-code/git.yml
@@ -54,7 +54,7 @@
 
 - name: ANSISTRANO | GIT | Set git_real_repo_tree
   set_fact:
-    ansistrano_git_real_repo_tree: "{{ ansistrano_git_repo_tree | trim | regex_replace('^[/]*', '') | regex_replace('[/]*$', '') }}"
+    ansistrano_git_real_repo_tree: "{{ ansistrano_git_repo_tree | trim | regex_replace('^[/]*', '') | regex_replace('([^/])/*$', '\\1/') | regex_replace('^[/]*$', '') }}"
 
 - name: ANSISTRANO | GIT | Create release folder
   file:
@@ -68,8 +68,8 @@
              git submodule foreach --recursive | sed -n -e "s/^Entering '\(.*\)'$/\1/p" | while read -r line; do (cd "$line"; git ls-files -z | tr "\0" "\n" | sed "s#^#$line/#"; cd $OLDPWD); done
            }
            | grep "^$prefix"
-           | sed "s#^$prefix/##"
-           | rsync -a --files-from=- "./$prefix/" {{ ansistrano_release_path.stdout }}/
+           | sed "s#^$prefix##"
+           | rsync -a --files-from=- "./$prefix" {{ ansistrano_release_path.stdout }}/
   args:
     chdir: "{{ ansistrano_deploy_to }}/{{ ansistrano_repo_dir }}/"
   environment:


### PR DESCRIPTION
fixes ansistrano/deploy#391

Tested with the following values of ansistrano_git_repo_tree
Tested setting ansistrano_git_repo_tree to the following:
unset
""
"/"
"/foo"
"/foo/"
"foo/"
"foo//"