### PR TITLE
Use plain variables for derived release paths

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -48,11 +48,10 @@
   rescue:
     - name: ANSISTRANO | Remove failed release
       file:
-        path: "{{ ansistrano_release_path.stdout }}"
+        path: "{{ ansistrano_release_path }}"
         state: absent
       when:
         - ansistrano_release_path is defined
-        - ansistrano_release_path.stdout is defined
         - not ansistrano_release_activated
 
     - fail:

--- a/tasks/rsync-deploy.yml
+++ b/tasks/rsync-deploy.yml
@@ -26,7 +26,7 @@
       - -F
       - --no-times
       - --delete-after
-      - "{{ ansistrano_release_path.stdout }}/"
+      - "{{ ansistrano_release_path }}/"
       - "{{ ansistrano_deploy_to }}/{{ ansistrano_current_dir }}/"
 
 # Ensure symlinks target paths is absent

--- a/tasks/symlink-shared.yml
+++ b/tasks/symlink-shared.yml
@@ -5,14 +5,14 @@
 - name: ANSISTRANO | Ensure shared paths targets are absent
   file:
     state: absent
-    path: "{{ ansistrano_release_path.stdout }}/{{ item }}"
+    path: "{{ ansistrano_release_path }}/{{ item }}"
   loop: "{{ (ansistrano_shared_paths | flatten ) + (ansistrano_shared_files | flatten) }}"
 
 # Symlinks shared paths and files
 - name: ANSISTRANO | Create softlinks for shared paths and files
   file:
     state: link
-    path: "{{ ansistrano_release_path.stdout }}/{{ item }}"
+    path: "{{ ansistrano_release_path }}/{{ item }}"
     src: "{{ item | regex_replace('[^\\/]+', '..') }}/../{{ ansistrano_shared_dir }}/{{ item }}"
   loop: "{{ (ansistrano_shared_paths | flatten ) + (ansistrano_shared_files | flatten) }}"
 
@@ -20,13 +20,13 @@
 - name: ANSISTRANO | Ensure .rsync-filter is absent
   file:
     state: absent
-    path: "{{ ansistrano_release_path.stdout }}/.rsync-filter"
+    path: "{{ ansistrano_release_path }}/.rsync-filter"
   when: ansistrano_current_via == "rsync"
 
 # Setup .rsync-filter file for current rsync deployment (exclude shared folders for rsync current deployment)
 - name: ANSISTRANO | Setup .rsync-filter with shared-folders
   lineinfile:
-    dest: "{{ ansistrano_release_path.stdout }}/.rsync-filter"
+    dest: "{{ ansistrano_release_path }}/.rsync-filter"
     line: "- /{{ item }}"
     create: yes
   loop: "{{ (ansistrano_shared_paths | flatten ) + (ansistrano_shared_files | flatten) }}"

--- a/tasks/update-code.yml
+++ b/tasks/update-code.yml
@@ -8,23 +8,22 @@
   delegate_to: 127.0.0.1
 
 - name: ANSISTRANO | Get release path
-  command: echo "{{ ansistrano_releases_path }}/{{ ansistrano_release_version }}"
-  check_mode: no
-  register: ansistrano_release_path
+  set_fact:
+    ansistrano_release_path: "{{ ansistrano_releases_path }}/{{ ansistrano_release_version }}"
 
 - include_tasks: "update-code/{{ ansistrano_deploy_via | default('rsync') }}.yml"
 
 - name: ANSISTRANO | Copy release version into REVISION file
   copy:
     content: "{{ ansistrano_release_version }}"
-    dest: "{{ ansistrano_release_path.stdout }}/REVISION"
+    dest: "{{ ansistrano_release_path }}/REVISION"
   when:
     - ansistrano_git_result is not defined or ansistrano_git_result is none
 
 - name: ANSISTRANO | Copy git released version into REVISION file
   copy:
     content: "{{ ansistrano_git_result.after | default(ansistrano_release_version) }}"
-    dest: "{{ ansistrano_release_path.stdout }}/REVISION"
+    dest: "{{ ansistrano_release_path }}/REVISION"
   when:
     - ansistrano_git_result is defined
     - ansistrano_git_result is not none

--- a/tasks/update-code/copy.yml
+++ b/tasks/update-code/copy.yml
@@ -2,9 +2,9 @@
 - name: ANSISTRANO | SCP | Create release folder
   file:
     state: directory
-    path: "{{ ansistrano_release_path.stdout }}"
+    path: "{{ ansistrano_release_path }}"
 
 - name: ANSISTRANO | SCP | Deploy existing code to remote servers
   copy:
     src: "{{ ansistrano_deploy_from }}"
-    dest: "{{ ansistrano_release_path.stdout }}"
+    dest: "{{ ansistrano_release_path }}"

--- a/tasks/update-code/copy_unarchive.yml
+++ b/tasks/update-code/copy_unarchive.yml
@@ -3,6 +3,6 @@
 
 - name: ANSISTRANO | copy_unarchive | Set archived file
   set_fact:
-    ansistrano_archived_file: "{{ ansistrano_release_path.stdout }}/{{ ansistrano_deploy_from | basename }}"
+    ansistrano_archived_file: "{{ ansistrano_release_path }}/{{ ansistrano_deploy_from | basename }}"
 
 - include_tasks: unarchive.yml

--- a/tasks/update-code/download.yml
+++ b/tasks/update-code/download.yml
@@ -2,12 +2,12 @@
 - name: ANSISTRANO | download | Create release folder
   file:
     state: directory
-    path: "{{ ansistrano_release_path.stdout }}"
+    path: "{{ ansistrano_release_path }}"
 
 - name: ANSISTRANO | download | Download artifact
   get_url:
     url: "{{ ansistrano_get_url }}"
-    dest: "{{ ansistrano_release_path.stdout }}/"
+    dest: "{{ ansistrano_release_path }}/"
     force_basic_auth: "{{ ansistrano_download_force_basic_auth | default(omit) }}"
     headers: "{{ ansistrano_download_headers | default(omit) }}"
   register: ansistrano_download_result

--- a/tasks/update-code/gcs.yml
+++ b/tasks/update-code/gcs.yml
@@ -2,7 +2,7 @@
 - name: ANSISTRANO | GC storage | Create release folder
   file:
     state: directory
-    path: "{{ ansistrano_release_path.stdout }}"
+    path: "{{ ansistrano_release_path }}"
 
 - name: ANSISTRANO | GC storage | Get object from GC storage
   gc_storage:
@@ -11,5 +11,5 @@
     region: "{{ ansistrano_gcs_region }}"
     gs_access_key: "{{ ansistrano_gcs_access_key | default(omit) }}"
     gs_secret_key: "{{ ansistrano_gcs_secret_key | default(omit) }}"
-    dest: "{{ ansistrano_release_path.stdout }}/{{ ansistrano_gcs_object | basename }}"
+    dest: "{{ ansistrano_release_path }}/{{ ansistrano_gcs_object | basename }}"
     mode: get

--- a/tasks/update-code/gcs_unarchive.yml
+++ b/tasks/update-code/gcs_unarchive.yml
@@ -3,6 +3,6 @@
 
 - name: ANSISTRANO | gcs_unarchive | Set archived file
   set_fact:
-    ansistrano_archived_file: "{{ ansistrano_release_path.stdout }}/{{ ansistrano_gcs_object | basename }}"
+    ansistrano_archived_file: "{{ ansistrano_release_path }}/{{ ansistrano_gcs_object | basename }}"
 
 - include_tasks: unarchive.yml

--- a/tasks/update-code/git.yml
+++ b/tasks/update-code/git.yml
@@ -63,7 +63,7 @@
 - name: ANSISTRANO | GIT | Create release folder
   file:
     state: directory
-    path: "{{ ansistrano_release_path.stdout }}"
+    path: "{{ ansistrano_release_path }}"
 
 - name: ANSISTRANO | GIT | Sync repo subtree["{{ ansistrano_git_real_repo_tree }}"] to release path
   shell: >-
@@ -73,7 +73,7 @@
            }
            | grep "^$prefix"
            | sed "s#^$prefix##"
-           | rsync -a --files-from=- "./$prefix" {{ ansistrano_release_path.stdout }}/
+           | rsync -a --files-from=- "./$prefix" {{ ansistrano_release_path }}/
   args:
     chdir: "{{ ansistrano_deploy_to }}/{{ ansistrano_repo_dir }}/"
   environment:

--- a/tasks/update-code/hg.yml
+++ b/tasks/update-code/hg.yml
@@ -10,7 +10,7 @@
 - name: ANSISTRANO | HG | Create release folder
   file:
     state: directory
-    path: "{{ ansistrano_release_path.stdout }}"
+    path: "{{ ansistrano_release_path }}"
 
 - name: ANSISTRANO | HG | Sync repo to release path
   command:
@@ -19,6 +19,6 @@
       - archive
       - -r
       - "{{ ansistrano_hg_branch }}"
-      - "{{ ansistrano_release_path.stdout }}"
+      - "{{ ansistrano_release_path }}"
   args:
     chdir: "{{ ansistrano_deploy_to }}/{{ ansistrano_repo_dir }}/"

--- a/tasks/update-code/rsync.yml
+++ b/tasks/update-code/rsync.yml
@@ -1,13 +1,12 @@
 ---
 - name: ANSISTRANO | RSYNC | Get shared path (in rsync case)
-  command: echo "{{ ansistrano_shared_path }}/.shared-copy"
-  check_mode: no
-  register: ansistrano_shared_rsync_copy_path
+  set_fact:
+    ansistrano_shared_rsync_copy_path: "{{ ansistrano_shared_path }}/.shared-copy"
 
 - name: ANSISTRANO | RSYNC | Rsync application files to remote shared copy
   synchronize:
     src: "{{ ansistrano_deploy_from }}"
-    dest: "{{ ansistrano_shared_rsync_copy_path.stdout }}"
+    dest: "{{ ansistrano_shared_rsync_copy_path }}"
     set_remote_user: "{{ ansistrano_rsync_set_remote_user }}"
     recursive: yes
     delete: yes
@@ -22,5 +21,5 @@
     argv:
       - cp
       - -a
-      - "{{ ansistrano_shared_rsync_copy_path.stdout }}"
-      - "{{ ansistrano_release_path.stdout }}"
+      - "{{ ansistrano_shared_rsync_copy_path }}"
+      - "{{ ansistrano_release_path }}"

--- a/tasks/update-code/rsync_direct.yml
+++ b/tasks/update-code/rsync_direct.yml
@@ -2,7 +2,7 @@
 - name: ANSISTRANO | RSYNC DIRECT | Rsync application files directly to remote release path
   synchronize:
     src: "{{ ansistrano_deploy_from }}"
-    dest: "{{ ansistrano_release_path.stdout }}"
+    dest: "{{ ansistrano_release_path }}"
     set_remote_user: "{{ ansistrano_rsync_set_remote_user }}"
     recursive: yes
     delete: yes

--- a/tasks/update-code/s3.yml
+++ b/tasks/update-code/s3.yml
@@ -2,13 +2,13 @@
 - name: ANSISTRANO | S3 | Create release folder
   file:
     state: directory
-    path: "{{ ansistrano_release_path.stdout }}"
+    path: "{{ ansistrano_release_path }}"
 
 - name: ANSISTRANO | S3 | Get object from S3
   aws_s3:
     bucket: "{{ ansistrano_s3_bucket }}"
     object: "{{ ansistrano_s3_object }}"
-    dest: "{{ ansistrano_release_path.stdout }}/{{ ansistrano_s3_object | basename }}"
+    dest: "{{ ansistrano_release_path }}/{{ ansistrano_s3_object | basename }}"
     mode: get
     region: "{{ ansistrano_s3_region }}"
     aws_access_key: "{{ ansistrano_s3_aws_access_key | default(omit) }}"
@@ -23,7 +23,7 @@
     encrypt: "{{ ansistrano_s3_encrypt | default(false) }}"
     bucket: "{{ ansistrano_s3_bucket }}"
     object: "{{ ansistrano_s3_object }}"
-    dest: "{{ ansistrano_release_path.stdout }}/{{ ansistrano_s3_object | basename }}"
+    dest: "{{ ansistrano_release_path }}/{{ ansistrano_s3_object | basename }}"
     mode: get
     aws_access_key: "{{ ansistrano_s3_aws_access_key | default(omit) }}"
     aws_secret_key: "{{ ansistrano_s3_aws_secret_key | default(omit) }}"

--- a/tasks/update-code/s3_unarchive.yml
+++ b/tasks/update-code/s3_unarchive.yml
@@ -3,6 +3,6 @@
 
 - name: ANSISTRANO | s3_unarchive | Set archived file
   set_fact:
-    ansistrano_archived_file: "{{ ansistrano_release_path.stdout }}/{{ ansistrano_s3_object | basename }}"
+    ansistrano_archived_file: "{{ ansistrano_release_path }}/{{ ansistrano_s3_object | basename }}"
 
 - include_tasks: unarchive.yml

--- a/tasks/update-code/svn.yml
+++ b/tasks/update-code/svn.yml
@@ -17,12 +17,12 @@
 - name: ANSISTRANO | SVN | Create release folder
   file:
     state: directory
-    path: "{{ ansistrano_release_path.stdout }}"
+    path: "{{ ansistrano_release_path }}"
 
 - name: ANSISTRANO | SVN | Copy repo to release path
   subversion:
     repo: "{{ ansistrano_deploy_to }}/{{ ansistrano_repo_dir }}"
-    dest: "{{ ansistrano_release_path.stdout }}"
+    dest: "{{ ansistrano_release_path }}"
     revision: "{{ ansistrano_svn_revision }}"
     username: "{{ ansistrano_svn_username }}"
     password: "{{ ansistrano_svn_password }}"

--- a/tasks/update-code/unarchive.yml
+++ b/tasks/update-code/unarchive.yml
@@ -12,7 +12,7 @@
   unarchive:
     copy: no
     src: "{{ ansistrano_archived_file }}"
-    dest: "{{ ansistrano_release_path.stdout }}"
+    dest: "{{ ansistrano_release_path }}"
     owner: "{{ ansistrano_unarchive_owner if ansistrano_unarchive_owner != 'default' else omit }}"
     group: "{{ ansistrano_unarchive_group if ansistrano_unarchive_group != 'default' else omit }}"
     exclude: "{{ ansistrano_unarchive_exclude }}"

--- a/test/download-test.yml
+++ b/test/download-test.yml
@@ -67,12 +67,12 @@
         groups: unarchive_group
 
   post_tasks:
-    - name: Assert ansistrano_release_path.stdout/deploy-master is owned by unarchive_user
+    - name: Assert ansistrano_release_path/deploy-master is owned by unarchive_user
       stat:
-        path: "{{ ansistrano_release_path.stdout }}/deploy-master"
+        path: "{{ ansistrano_release_path }}/deploy-master"
       register: st
     - debug:
-        msg: "ansistrano_release_path.stdout/deploy-master is owned by unarchive_user"
+        msg: "ansistrano_release_path/deploy-master is owned by unarchive_user"
       when: st.stat.gr_name == "unarchive_group" and st.stat.pw_name == "unarchive_user"
 
 - name: When deploying using download strategy and setting owner (expect fail)
@@ -86,12 +86,12 @@
   roles:
     - { role: local-ansistrano }
   post_tasks:
-    - name: Assert ansistrano_release_path.stdout/deploy-master does not exist
+    - name: Assert ansistrano_release_path/deploy-master does not exist
       stat:
-        path: "{{ ansistrano_release_path.stdout }}/deploy-master"
+        path: "{{ ansistrano_release_path }}/deploy-master"
       register: st
     - debug:
-        msg: "ansistrano_release_path.stdout/deploy-master does not exist"
+        msg: "ansistrano_release_path/deploy-master does not exist"
       when: st.stat.exists is sameas false
 
 - name: When deploying using download strategy and a very long url + querystring
@@ -105,12 +105,12 @@
   roles:
     - { role: local-ansistrano }
   post_tasks:
-    - name: Assert ansistrano_release_path.stdout/deploy-master does not exist
+    - name: Assert ansistrano_release_path/deploy-master does not exist
       stat:
-        path: "{{ ansistrano_release_path.stdout }}/deploy-master"
+        path: "{{ ansistrano_release_path }}/deploy-master"
       register: st
     - debug:
-        msg: "ansistrano_release_path.stdout/deploy-master does not exist"
+        msg: "ansistrano_release_path/deploy-master does not exist"
       when: st.stat.exists is sameas false
 
 - name: Given a local artifact endpoint with filename only in Content-Disposition

--- a/test/tasks/create-internal-paths.yml
+++ b/test/tasks/create-internal-paths.yml
@@ -3,14 +3,14 @@
 - name: ANSISTRANO | Ensure internal path foo exists
   file:
     state: directory
-    path: "{{ ansistrano_release_path.stdout }}/foo"
+    path: "{{ ansistrano_release_path }}/foo"
 
 - name: ANSISTRANO | Ensure internal path xxx/yyy exists
   file:
     state: directory
-    path: "{{ ansistrano_release_path.stdout }}/xxx/yyy"
+    path: "{{ ansistrano_release_path }}/xxx/yyy"
 
 - name: ANSISTRANO | Ensure internal path files exists
   file:
     state: directory
-    path: "{{ ansistrano_release_path.stdout }}/files"
+    path: "{{ ansistrano_release_path }}/files"


### PR DESCRIPTION
## Summary
- replace command/register-based derived path values with plain Ansible facts
- remove the remaining  usage for derived release path variables
- keep the role behavior the same while making path handling more coherent

## Validation
- ./scripts/test-in-docker.sh syntax
- ./scripts/test-in-docker.sh integration